### PR TITLE
Feat/db typed queries re-PR

### DIFF
--- a/database_schema.sql
+++ b/database_schema.sql
@@ -1,11 +1,11 @@
--- Enable UUID extension
-CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+-- Enable UUID extension (older pg versions)
+-- CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
 -- ============================================
 -- 1. USERS TABLE (no dependencies)
 -- ============================================
 CREATE TABLE users (
-  user_id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  user_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   user_name VARCHAR(100) NOT NULL UNIQUE,
   email VARCHAR(255) NOT NULL UNIQUE,
   password_hash VARCHAR(255) NOT NULL,
@@ -20,7 +20,7 @@ CREATE TABLE users (
 -- 2. QUESTIONS TABLE (depends on users)
 -- ============================================
 CREATE TABLE questions (
-  question_id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  question_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id UUID NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
   content TEXT NOT NULL,
   category VARCHAR(100) NOT NULL,
@@ -34,7 +34,7 @@ CREATE TABLE questions (
 -- 3. TUTORIALS TABLE (depends on users, questions)
 -- ============================================
 CREATE TABLE tutorials (
-  tutorial_id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  tutorial_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id UUID NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
   question_id UUID REFERENCES questions(question_id) ON DELETE SET NULL,
   title VARCHAR(255) NOT NULL,
@@ -67,7 +67,7 @@ CREATE TABLE comments (
   answer_id INTEGER REFERENCES answers(answer_id) ON DELETE CASCADE,
   tutorial_id UUID REFERENCES tutorials(tutorial_id) ON DELETE CASCADE,
   created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-  
+
   CHECK (
     (question_id IS NOT NULL AND answer_id IS NULL AND tutorial_id IS NULL) OR
     (question_id IS NULL AND answer_id IS NOT NULL AND tutorial_id IS NULL) OR
@@ -97,7 +97,7 @@ CREATE TABLE interactions (
   comment_id INTEGER REFERENCES comments(comment_id) ON DELETE CASCADE,
   tutorial_id UUID REFERENCES tutorials(tutorial_id) ON DELETE CASCADE,
   created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-  
+
   CHECK (
     (question_id IS NOT NULL AND answer_id IS NULL AND comment_id IS NULL AND tutorial_id IS NULL) OR
     (question_id IS NULL AND answer_id IS NOT NULL AND comment_id IS NULL AND tutorial_id IS NULL) OR
@@ -160,7 +160,7 @@ CREATE UNIQUE INDEX unique_user_tutorial_interaction ON interactions(user_id, tu
 
 -- Questions with author info and statistics
 CREATE VIEW question_details AS
-SELECT 
+SELECT
   q.question_id,
   q.user_id,
   q.content,
@@ -182,7 +182,7 @@ GROUP BY q.question_id, q.user_id, q.content, q.category, q.demand_score, q.popp
 
 -- Tutorials with popularity
 CREATE VIEW tutorial_stats AS
-SELECT 
+SELECT
   t.tutorial_id,
   t.user_id,
   t.question_id,
@@ -199,8 +199,8 @@ JOIN users u ON t.user_id = u.user_id
 LEFT JOIN interactions i ON t.tutorial_id = i.tutorial_id
 GROUP BY t.tutorial_id, t.user_id, t.question_id, t.title, t.content, t.embedded_video_url, t.created_at, u.user_name;
 
-SELECT table_name 
-FROM information_schema.tables 
-WHERE table_schema = 'public' 
+SELECT table_name
+FROM information_schema.tables
+WHERE table_schema = 'public'
   AND table_type = 'BASE TABLE'
 ORDER BY table_name;

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,8 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { one } from '@/lib/db';
-import { verifyPassword, generateToken } from '@/lib/auth';
-import { ValidationError, AuthError, errorToResponse } from '@/lib/errors';
-import type { User } from '@/types/database';
+import { generateToken, verifyPassword } from "@/lib/auth";
+import { AuthError, errorToResponse, ValidationError } from "@/lib/errors";
+import { getUserByEmail } from "@/lib/queries/users";
+import { NextRequest, NextResponse } from "next/server";
 
 export async function POST(request: NextRequest) {
   try {
@@ -10,10 +9,10 @@ export async function POST(request: NextRequest) {
     const { email, password } = body;
 
     if (!email || !password) {
-      throw new ValidationError('Email and password are required');
+      throw new ValidationError("Email and password are required");
     }
 
-    const user = await one<User>('SELECT * FROM users WHERE email = $1', [email]);
+    const user = await getUserByEmail(email);
 
     if (!user) {
       throw new AuthError();

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -1,42 +1,69 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { one } from '@/lib/db';
-import { hashPassword, generateToken } from '@/lib/auth';
-import { ValidationError, ConflictError, errorToResponse } from '@/lib/errors';
-import type { User } from '@/types/database';
+import { generateToken, hashPassword } from "@/lib/auth";
+import { ConflictError, errorToResponse, ValidationError } from "@/lib/errors";
+import {
+  getUserByEmail,
+  getUserByUsername,
+  insertUser,
+} from "@/lib/queries/users";
+import { NextRequest, NextResponse } from "next/server";
 
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
-    const { user_name, email, password, age, gender, institution, education_level } = body;
+    const {
+      user_name,
+      email,
+      password,
+      age,
+      gender,
+      institution,
+      education_level,
+    } = body;
 
-    if (!user_name || !email || !password || !age || !gender || !institution || !education_level) {
-      throw new ValidationError('All fields are required');
+    if (
+      !user_name ||
+      !email ||
+      !password ||
+      !age ||
+      !gender ||
+      !institution ||
+      !education_level
+    ) {
+      throw new ValidationError("All fields are required");
     }
 
-    const existingEmail = await one<User>('SELECT * FROM users WHERE email = $1', [email]);
+    const existingEmail = await getUserByEmail(email);
     if (existingEmail) {
-      throw new ConflictError('Email already registered');
+      throw new ConflictError("Email already registered");
     }
 
-    const existingUsername = await one<User>('SELECT * FROM users WHERE user_name = $1', [user_name]);
+    const existingUsername = await getUserByUsername(user_name);
     if (existingUsername) {
-      throw new ConflictError('Username already taken');
+      throw new ConflictError("Username already taken");
     }
 
     const password_hash = await hashPassword(password);
 
-    const newUser = await one<User>(
-      `INSERT INTO users (user_id, user_name, email, password_hash, age, gender, institution, education_level)
-       VALUES (uuid_generate_v4(), $1, $2, $3, $4, $5, $6, $7)
-       RETURNING user_id, user_name, email, institution, age, gender, education_level, created_at`,
-      [user_name, email, password_hash, parseInt(age), gender, institution, education_level],
-    );
+    const newUser = await insertUser({
+      user_name,
+      email,
+      password_hash,
+      age: parseInt(age),
+      gender,
+      institution,
+      education_level,
+    });
 
-    return NextResponse.json({
-      success: true,
-      user: newUser,
-      token: generateToken(newUser!.user_id),
-    }, { status: 201 });
+    const { password_hash: _ph, ...userWithoutPassword } = newUser;
+
+    return NextResponse.json(
+      {
+        success: true,
+        user: userWithoutPassword,
+        token: generateToken(newUser.user_id),
+      },
+      { status: 201 },
+    );
   } catch (error) {
     return errorToResponse(error);
   }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,47 +1,26 @@
-import 'server-only';
-import bcrypt from 'bcrypt';
-import jwt from 'jsonwebtoken';
-import { one } from './db';
-import type { User } from '@/types/database';
+import type { User } from "@/types/database";
+import bcrypt from "bcrypt";
+import jwt from "jsonwebtoken";
+import "server-only";
 
-type UserID = User['user_id'];
+type UserID = User["user_id"];
 
-const JWT_SECRET = process.env.JWT_SECRET || 'your-secret-key-change-in-production';
+const JWT_SECRET = process.env.JWT_SECRET as string;
+if (!JWT_SECRET) throw new Error("JWT_SECRET environment variable is required");
+
 const SALT_ROUNDS = 10;
 
 export async function hashPassword(password: string): Promise<string> {
   return bcrypt.hash(password, SALT_ROUNDS);
 }
 
-export async function verifyPassword(password: string, hash: string): Promise<boolean> {
+export async function verifyPassword(
+  password: string,
+  hash: string,
+): Promise<boolean> {
   return bcrypt.compare(password, hash);
 }
 
 export function generateToken(userId: UserID): string {
-  return jwt.sign({ userId }, JWT_SECRET, { expiresIn: '7d' });
-}
-
-export async function getUserByEmail(email: string): Promise<User | null> {
-  return one<User>('SELECT * FROM users WHERE email = $1', [email]);
-}
-
-export async function createUser(userData: {
-  user_name: string;
-  email: string;
-  password: string;
-  age: number;
-  gender: 'male' | 'female' | 'other';
-  institution: string;
-  education_level: 'high_school' | 'bachelor' | 'master' | 'doctorate' | 'other';
-}): Promise<User> {
-  const password_hash = await hashPassword(userData.password);
-  const row = await one<User>(
-    `INSERT INTO users (user_id, user_name, email, password_hash, age, gender, institution, education_level)
-     VALUES (uuid_generate_v4(), $1, $2, $3, $4, $5, $6, $7)
-     RETURNING *`,
-    [userData.user_name, userData.email, password_hash,
-     userData.age, userData.gender, userData.institution, userData.education_level],
-  );
-  if (!row) throw new Error('createUser: no row returned');
-  return row;
+  return jwt.sign({ userId }, JWT_SECRET, { expiresIn: "7d" });
 }

--- a/src/lib/db-brands.ts
+++ b/src/lib/db-brands.ts
@@ -1,21 +1,26 @@
-import 'server-only';
+import { DatabaseError } from "@/lib/errors";
 import type {
-  UserID, QuestionID, TutorialID,
-  AnswerID, CommentID, InteractionID,
+  AnswerID,
+  CommentID,
   Interaction,
-} from '@/types/database';
+  InteractionID,
+  QuestionID,
+  TutorialID,
+  UserID,
+} from "@/types/database";
+import "server-only";
 
-export const asUserId        = (s: string) => s as UserID;
-export const asQuestionId    = (s: string) => s as QuestionID;
-export const asTutorialId    = (s: string) => s as TutorialID;
-export const asAnswerId      = (n: number) => n as AnswerID;
-export const asCommentId     = (n: number) => n as CommentID;
+export const asUserId = (s: string) => s as UserID;
+export const asQuestionId = (s: string) => s as QuestionID;
+export const asTutorialId = (s: string) => s as TutorialID;
+export const asAnswerId = (n: number) => n as AnswerID;
+export const asCommentId = (n: number) => n as CommentID;
 export const asInteractionId = (n: number) => n as InteractionID;
 
 export type InteractionRow = {
   interaction_id: number;
   user_id: string;
-  interaction_type: 'react' | 'rating';
+  interaction_type: "react" | "rating";
   value: number | null;
   created_at: Date;
   question_id: string | null;
@@ -25,11 +30,15 @@ export type InteractionRow = {
 };
 
 export function rowToInteraction(r: InteractionRow): Interaction {
-  const setCount = [r.question_id, r.answer_id, r.comment_id, r.tutorial_id]
-    .filter(v => v !== null).length;
+  const setCount = [
+    r.question_id,
+    r.answer_id,
+    r.comment_id,
+    r.tutorial_id,
+  ].filter((v) => v !== null).length;
 
   if (setCount !== 1) {
-    throw new Error(
+    throw new DatabaseError(
       `Interaction ${r.interaction_id} violates exactly-one-FK CHECK constraint: ${setCount} FK(s) set, expected 1`,
     );
   }
@@ -42,8 +51,11 @@ export function rowToInteraction(r: InteractionRow): Interaction {
     created_at: r.created_at,
   };
 
-  if (r.question_id !== null) return { ...base, question_id: asQuestionId(r.question_id) };
-  if (r.answer_id   !== null) return { ...base, answer_id:   asAnswerId(r.answer_id) };
-  if (r.comment_id  !== null) return { ...base, comment_id:  asCommentId(r.comment_id) };
+  if (r.question_id !== null)
+    return { ...base, question_id: asQuestionId(r.question_id) };
+  if (r.answer_id !== null)
+    return { ...base, answer_id: asAnswerId(r.answer_id) };
+  if (r.comment_id !== null)
+    return { ...base, comment_id: asCommentId(r.comment_id) };
   return { ...base, tutorial_id: asTutorialId(r.tutorial_id!) };
 }

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from 'next/server';
+import { NextResponse } from "next/server";
 
 export class AppError extends Error {
   readonly statusCode: number;
@@ -13,19 +13,33 @@ export class AppError extends Error {
 }
 
 export class ValidationError extends AppError {
-  constructor(message: string) { super(message, 400, 'VALIDATION_ERROR'); }
+  constructor(message: string) {
+    super(message, 400, "VALIDATION_ERROR");
+  }
 }
 
 export class AuthError extends AppError {
-  constructor(message = 'Invalid email or password') { super(message, 401, 'AUTH_ERROR'); }
+  constructor(message = "Invalid email or password") {
+    super(message, 401, "AUTH_ERROR");
+  }
 }
 
 export class NotFoundError extends AppError {
-  constructor(message = 'Not found') { super(message, 404, 'NOT_FOUND'); }
+  constructor(message = "Not found") {
+    super(message, 404, "NOT_FOUND");
+  }
 }
 
 export class ConflictError extends AppError {
-  constructor(message: string) { super(message, 409, 'CONFLICT'); }
+  constructor(message: string) {
+    super(message, 409, "CONFLICT");
+  }
+}
+
+export class DatabaseError extends AppError {
+  constructor(message = "Database operation failed") {
+    super(message, 500, "DATABASE_ERROR");
+  }
 }
 
 export function errorToResponse(error: unknown): NextResponse {
@@ -36,9 +50,10 @@ export function errorToResponse(error: unknown): NextResponse {
     );
   }
 
-  const message = error instanceof Error ? error.message : 'Unknown error';
+  const message = error instanceof Error ? error.message : "Unknown error";
+  console.error("[Unhandled Error]", error);
   return NextResponse.json(
-    { error: message, code: 'INTERNAL_ERROR' },
+    { error: "Internal Server Error", code: "INTERNAL_ERROR" },
     { status: 500 },
   );
 }

--- a/src/lib/queries/answers.ts
+++ b/src/lib/queries/answers.ts
@@ -1,9 +1,10 @@
-import 'server-only';
-import { q, one } from '@/lib/db';
-import { asAnswerId } from '@/lib/db-brands';
-import type { Answers, AnswerID, QuestionID, UserID } from '@/types/database';
+import { one, q } from "@/lib/db";
+import { asAnswerId, asQuestionId, asUserId } from "@/lib/db-brands";
+import { DatabaseError } from "@/lib/errors";
+import type { AnswerID, Answers, QuestionID, UserID } from "@/types/database";
+import "server-only";
 
-type AnswerRow = Omit<Answers, 'answer_id' | 'user_id' | 'question_id'> & {
+type AnswerRow = Omit<Answers, "answer_id" | "user_id" | "question_id"> & {
   answer_id: number;
   user_id: string;
   question_id: string;
@@ -13,22 +14,24 @@ function mapAnswer(r: AnswerRow): Answers {
   return {
     ...r,
     answer_id: asAnswerId(r.answer_id),
-    user_id: r.user_id as UserID,
-    question_id: r.question_id as QuestionID,
+    user_id: asUserId(r.user_id),
+    question_id: asQuestionId(r.question_id),
   };
 }
 
 export async function getAnswerById(id: AnswerID): Promise<Answers | null> {
   const row = await one<AnswerRow>(
-    'SELECT * FROM answers WHERE answer_id = $1',
+    "SELECT * FROM answers WHERE answer_id = $1",
     [id],
   );
   return row ? mapAnswer(row) : null;
 }
 
-export async function listAnswersForQuestion(qid: QuestionID): Promise<Answers[]> {
+export async function listAnswersForQuestion(
+  qid: QuestionID,
+): Promise<Answers[]> {
   const rows = await q<AnswerRow>(
-    'SELECT * FROM answers WHERE question_id = $1 ORDER BY created_at ASC',
+    "SELECT * FROM answers WHERE question_id = $1 ORDER BY created_at ASC",
     [qid],
   );
   return rows.map(mapAnswer);
@@ -45,13 +48,13 @@ export async function insertAnswer(
      RETURNING *`,
     [user_id, question_id, content],
   );
-  if (!row) throw new Error('insertAnswer: no row returned');
+  if (!row) throw new DatabaseError("insertAnswer: no row returned");
   return mapAnswer(row);
 }
 
 export async function acceptAnswer(id: AnswerID): Promise<Answers | null> {
   const row = await one<AnswerRow>(
-    'UPDATE answers SET is_accepted = true WHERE answer_id = $1 RETURNING *',
+    "UPDATE answers SET is_accepted = true WHERE answer_id = $1 RETURNING *",
     [id],
   );
   return row ? mapAnswer(row) : null;

--- a/src/lib/queries/comments.ts
+++ b/src/lib/queries/comments.ts
@@ -1,9 +1,30 @@
-import 'server-only';
-import { q, one } from '@/lib/db';
-import { asCommentId } from '@/lib/db-brands';
-import type { Comments, CommentID, UserID, QuestionID, AnswerID, TutorialID } from '@/types/database';
+import { one, q } from "@/lib/db";
+import {
+  asAnswerId,
+  asCommentId,
+  asQuestionId,
+  asTutorialId,
+  asUserId,
+} from "@/lib/db-brands";
+import { DatabaseError } from "@/lib/errors";
+import type {
+  AnswerID,
+  CommentID,
+  Comments,
+  QuestionID,
+  TutorialID,
+} from "@/types/database";
+import "server-only";
 
-type CommentRow = Omit<Comments, 'comment_id' | 'user_id' | 'parent_comment_id' | 'question_id' | 'answer_id' | 'tutorial_id'> & {
+type CommentRow = Omit<
+  Comments,
+  | "comment_id"
+  | "user_id"
+  | "parent_comment_id"
+  | "question_id"
+  | "answer_id"
+  | "tutorial_id"
+> & {
   comment_id: number;
   user_id: string;
   parent_comment_id: number | null;
@@ -16,57 +37,70 @@ function mapComment(r: CommentRow): Comments {
   return {
     ...r,
     comment_id: asCommentId(r.comment_id),
-    user_id: r.user_id as UserID,
-    parent_comment_id: r.parent_comment_id !== null ? asCommentId(r.parent_comment_id) : null,
-    question_id: r.question_id as QuestionID,
-    answer_id: r.answer_id !== null ? (r.answer_id as unknown as AnswerID) : null,
-    tutorial_id: r.tutorial_id !== null ? (r.tutorial_id as unknown as TutorialID) : null,
+    user_id: asUserId(r.user_id),
+    parent_comment_id:
+      r.parent_comment_id !== null ? asCommentId(r.parent_comment_id) : null,
+    question_id: asQuestionId(r.question_id),
+    answer_id: r.answer_id !== null ? asAnswerId(r.answer_id) : null,
+    tutorial_id: r.tutorial_id !== null ? asTutorialId(r.tutorial_id) : null,
   };
 }
 
 export async function getCommentById(id: CommentID): Promise<Comments | null> {
   const row = await one<CommentRow>(
-    'SELECT * FROM comments WHERE comment_id = $1',
+    "SELECT * FROM comments WHERE comment_id = $1",
     [id],
   );
   return row ? mapComment(row) : null;
 }
 
-export async function listCommentsForQuestion(qid: QuestionID): Promise<Comments[]> {
+export async function listCommentsForQuestion(
+  qid: QuestionID,
+): Promise<Comments[]> {
   const rows = await q<CommentRow>(
-    'SELECT * FROM comments WHERE question_id = $1 ORDER BY created_at ASC',
+    "SELECT * FROM comments WHERE question_id = $1 ORDER BY created_at ASC",
     [qid],
   );
   return rows.map(mapComment);
 }
 
-export async function listCommentsForAnswer(aid: AnswerID): Promise<Comments[]> {
+export async function listCommentsForAnswer(
+  aid: AnswerID,
+): Promise<Comments[]> {
   const rows = await q<CommentRow>(
-    'SELECT * FROM comments WHERE answer_id = $1 ORDER BY created_at ASC',
+    "SELECT * FROM comments WHERE answer_id = $1 ORDER BY created_at ASC",
     [aid],
   );
   return rows.map(mapComment);
 }
 
-export async function listCommentsForTutorial(tid: TutorialID): Promise<Comments[]> {
+export async function listCommentsForTutorial(
+  tid: TutorialID,
+): Promise<Comments[]> {
   const rows = await q<CommentRow>(
-    'SELECT * FROM comments WHERE tutorial_id = $1 ORDER BY created_at ASC',
+    "SELECT * FROM comments WHERE tutorial_id = $1 ORDER BY created_at ASC",
     [tid],
   );
   return rows.map(mapComment);
 }
 
 export async function insertComment(
-  input: Omit<Comments, 'comment_id' | 'created_at'>,
+  input: Omit<Comments, "comment_id" | "created_at">,
 ): Promise<Comments> {
   const row = await one<CommentRow>(
     `INSERT INTO comments
        (user_id, content, parent_comment_id, question_id, answer_id, tutorial_id)
      VALUES ($1, $2, $3, $4, $5, $6)
      RETURNING *`,
-    [input.user_id, input.content, input.parent_comment_id,
-     input.question_id, input.answer_id, input.tutorial_id],
+    [
+      input.user_id,
+      input.content,
+      input.parent_comment_id,
+      input.question_id,
+      input.answer_id,
+      input.tutorial_id,
+    ],
   );
-  if (!row) throw new Error('insertComment: no row returned');
+  if (!row) throw new DatabaseError("insertComment: no row returned");
   return mapComment(row);
 }

--- a/src/lib/queries/interactions.ts
+++ b/src/lib/queries/interactions.ts
@@ -1,40 +1,52 @@
-import 'server-only';
-import { q, one } from '@/lib/db';
-import { rowToInteraction, type InteractionRow } from '@/lib/db-brands';
-import type { Interaction, InteractionID, UserID } from '@/types/database';
+import { one, q } from "@/lib/db";
+import { rowToInteraction, type InteractionRow } from "@/lib/db-brands";
+import { DatabaseError } from "@/lib/errors";
+import type { Interaction, InteractionID, UserID } from "@/types/database";
+import "server-only";
 
-export async function getInteractionById(id: InteractionID): Promise<Interaction | null> {
+export async function getInteractionById(
+  id: InteractionID,
+): Promise<Interaction | null> {
   const row = await one<InteractionRow>(
-    'SELECT * FROM interactions WHERE interaction_id = $1',
+    "SELECT * FROM interactions WHERE interaction_id = $1",
     [id],
   );
   return row ? rowToInteraction(row) : null;
 }
 
-export async function listInteractionsByUser(uid: UserID): Promise<Interaction[]> {
+export async function listInteractionsByUser(
+  uid: UserID,
+): Promise<Interaction[]> {
   const rows = await q<InteractionRow>(
-    'SELECT * FROM interactions WHERE user_id = $1 ORDER BY created_at DESC',
+    "SELECT * FROM interactions WHERE user_id = $1 ORDER BY created_at DESC",
     [uid],
   );
   return rows.map(rowToInteraction);
 }
 
 export async function insertInteraction(
-  input: Omit<Interaction, 'interaction_id' | 'created_at'>,
+  input: Omit<Interaction, "interaction_id" | "created_at">,
 ): Promise<Interaction> {
-  const question_id = 'question_id' in input ? input.question_id : null;
-  const answer_id   = 'answer_id'   in input ? input.answer_id   : null;
-  const comment_id  = 'comment_id'  in input ? input.comment_id  : null;
-  const tutorial_id = 'tutorial_id' in input ? input.tutorial_id : null;
+  const question_id = "question_id" in input ? input.question_id : null;
+  const answer_id = "answer_id" in input ? input.answer_id : null;
+  const comment_id = "comment_id" in input ? input.comment_id : null;
+  const tutorial_id = "tutorial_id" in input ? input.tutorial_id : null;
 
   const row = await one<InteractionRow>(
     `INSERT INTO interactions
        (user_id, interaction_type, value, question_id, answer_id, comment_id, tutorial_id)
      VALUES ($1, $2, $3, $4, $5, $6, $7)
      RETURNING *`,
-    [input.user_id, input.interaction_type, input.value,
-     question_id, answer_id, comment_id, tutorial_id],
+    [
+      input.user_id,
+      input.interaction_type,
+      input.value,
+      question_id,
+      answer_id,
+      comment_id,
+      tutorial_id,
+    ],
   );
-  if (!row) throw new Error('insertInteraction: no row returned');
+  if (!row) throw new DatabaseError("insertInteraction: no row returned");
   return rowToInteraction(row);
 }

--- a/src/lib/queries/questions-tutorials.ts
+++ b/src/lib/queries/questions-tutorials.ts
@@ -1,13 +1,18 @@
-import 'server-only';
-import { q } from '@/lib/db';
-import type { QuestionsTutorials, QuestionID, TutorialID } from '@/types/database';
+import { q } from "@/lib/db";
+import { asQuestionId, asTutorialId } from "@/lib/db-brands";
+import type {
+  QuestionID,
+  QuestionsTutorials,
+  TutorialID,
+} from "@/types/database";
+import "server-only";
 
 type QTRow = { question_id: string; tutorial_id: string };
 
 function mapQT(r: QTRow): QuestionsTutorials {
   return {
-    question_id: r.question_id as QuestionID,
-    tutorial_id: r.tutorial_id as TutorialID,
+    question_id: asQuestionId(r.question_id),
+    tutorial_id: asTutorialId(r.tutorial_id),
   };
 }
 
@@ -35,9 +40,11 @@ export async function unlinkQuestionTutorial(
   return rows.map(mapQT);
 }
 
-export async function tutorialsForQuestion(qid: QuestionID): Promise<QuestionsTutorials[]> {
+export async function tutorialsForQuestion(
+  qid: QuestionID,
+): Promise<QuestionsTutorials[]> {
   const rows = await q<QTRow>(
-    'SELECT * FROM questions_tutorials WHERE question_id = $1',
+    "SELECT * FROM questions_tutorials WHERE question_id = $1",
     [qid],
   );
   return rows.map(mapQT);

--- a/src/lib/queries/questions.ts
+++ b/src/lib/queries/questions.ts
@@ -1,9 +1,10 @@
-import 'server-only';
-import { q, one } from '@/lib/db';
-import { asQuestionId } from '@/lib/db-brands';
-import type { Questions, QuestionID, UserID } from '@/types/database';
+import { one, q } from "@/lib/db";
+import { asQuestionId, asUserId } from "@/lib/db-brands";
+import { DatabaseError } from "@/lib/errors";
+import type { QuestionID, Questions, UserID } from "@/types/database";
+import "server-only";
 
-type QuestionRow = Omit<Questions, 'question_id' | 'user_id'> & {
+type QuestionRow = Omit<Questions, "question_id" | "user_id"> & {
   question_id: string;
   user_id: string;
 };
@@ -12,21 +13,26 @@ function mapQuestion(r: QuestionRow): Questions {
   return {
     ...r,
     question_id: asQuestionId(r.question_id),
-    user_id: r.user_id as UserID,
+    user_id: asUserId(r.user_id),
   };
 }
 
-export async function getQuestionById(id: QuestionID): Promise<Questions | null> {
+export async function getQuestionById(
+  id: QuestionID,
+): Promise<Questions | null> {
   const row = await one<QuestionRow>(
-    'SELECT * FROM questions WHERE question_id = $1',
+    "SELECT * FROM questions WHERE question_id = $1",
     [id],
   );
   return row ? mapQuestion(row) : null;
 }
 
-export async function listQuestions(limit: number, offset: number): Promise<Questions[]> {
+export async function listQuestions(
+  limit: number,
+  offset: number,
+): Promise<Questions[]> {
   const rows = await q<QuestionRow>(
-    'SELECT * FROM questions ORDER BY created_at DESC LIMIT $1 OFFSET $2',
+    "SELECT * FROM questions ORDER BY created_at DESC LIMIT $1 OFFSET $2",
     [Math.min(Math.max(limit, 1), 100), Math.max(offset, 0)],
   );
   return rows.map(mapQuestion);
@@ -40,17 +46,17 @@ export async function insertQuestion(
   const row = await one<QuestionRow>(
     `INSERT INTO questions
        (question_id, user_id, content, category, demand_score, popped)
-     VALUES (uuid_generate_v4(), $1, $2, $3, 0, false)
+     VALUES (gen_random_uuid(), $1, $2, $3, 0, false)
      RETURNING *`,
     [user_id, content, category],
   );
-  if (!row) throw new Error('insertQuestion: no row returned');
+  if (!row) throw new DatabaseError("insertQuestion: no row returned");
   return mapQuestion(row);
 }
 
 export async function markResolved(id: QuestionID): Promise<Questions | null> {
   const row = await one<QuestionRow>(
-    'UPDATE questions SET resolved_at = now() WHERE question_id = $1 RETURNING *',
+    "UPDATE questions SET resolved_at = now() WHERE question_id = $1 RETURNING *",
     [id],
   );
   return row ? mapQuestion(row) : null;

--- a/src/lib/queries/tutorials.ts
+++ b/src/lib/queries/tutorials.ts
@@ -1,9 +1,18 @@
-import 'server-only';
-import { q, one } from '@/lib/db';
-import { asTutorialId } from '@/lib/db-brands';
-import type { Tutorials, TutorialID, UserID, QuestionID } from '@/types/database';
+import { one, q } from "@/lib/db";
+import { asQuestionId, asTutorialId, asUserId } from "@/lib/db-brands";
+import { DatabaseError } from "@/lib/errors";
+import type {
+  QuestionID,
+  TutorialID,
+  Tutorials,
+  UserID,
+} from "@/types/database";
+import "server-only";
 
-type TutorialRow = Omit<Tutorials, 'tutorial_id' | 'user_id' | 'question_id'> & {
+type TutorialRow = Omit<
+  Tutorials,
+  "tutorial_id" | "user_id" | "question_id"
+> & {
   tutorial_id: string;
   user_id: string;
   question_id: string | null;
@@ -13,22 +22,27 @@ function mapTutorial(r: TutorialRow): Tutorials {
   return {
     ...r,
     tutorial_id: asTutorialId(r.tutorial_id),
-    user_id: r.user_id as UserID,
-    question_id: r.question_id !== null ? (r.question_id as unknown as QuestionID) : null,
+    user_id: asUserId(r.user_id),
+    question_id: r.question_id !== null ? asQuestionId(r.question_id) : null,
   };
 }
 
-export async function getTutorialById(id: TutorialID): Promise<Tutorials | null> {
+export async function getTutorialById(
+  id: TutorialID,
+): Promise<Tutorials | null> {
   const row = await one<TutorialRow>(
-    'SELECT * FROM tutorials WHERE tutorial_id = $1',
+    "SELECT * FROM tutorials WHERE tutorial_id = $1",
     [id],
   );
   return row ? mapTutorial(row) : null;
 }
 
-export async function listTutorials(limit: number, offset: number): Promise<Tutorials[]> {
+export async function listTutorials(
+  limit: number,
+  offset: number,
+): Promise<Tutorials[]> {
   const rows = await q<TutorialRow>(
-    'SELECT * FROM tutorials ORDER BY created_at DESC LIMIT $1 OFFSET $2',
+    "SELECT * FROM tutorials ORDER BY created_at DESC LIMIT $1 OFFSET $2",
     [Math.min(Math.max(limit, 1), 100), Math.max(offset, 0)],
   );
   return rows.map(mapTutorial);
@@ -44,10 +58,16 @@ export async function insertTutorial(input: {
   const row = await one<TutorialRow>(
     `INSERT INTO tutorials
        (tutorial_id, user_id, question_id, title, content, embedded_video_url)
-     VALUES (uuid_generate_v4(), $1, $2, $3, $4, $5)
+     VALUES (gen_random_uuid(), $1, $2, $3, $4, $5)
      RETURNING *`,
-    [input.user_id, input.question_id, input.title, input.content, input.embedded_video_url],
+    [
+      input.user_id,
+      input.question_id,
+      input.title,
+      input.content,
+      input.embedded_video_url,
+    ],
   );
-  if (!row) throw new Error('insertTutorial: no row returned');
+  if (!row) throw new DatabaseError("insertTutorial: no row returned");
   return mapTutorial(row);
 }

--- a/src/lib/queries/users.ts
+++ b/src/lib/queries/users.ts
@@ -1,35 +1,56 @@
-import 'server-only';
-import { q, one } from '@/lib/db';
-import { asUserId } from '@/lib/db-brands';
-import type { User, UserID } from '@/types/database';
+import { one } from "@/lib/db";
+import { asUserId } from "@/lib/db-brands";
+import { DatabaseError } from "@/lib/errors";
+import type { User, UserID } from "@/types/database";
+import "server-only";
 
-type UserRow = Omit<User, 'user_id'> & { user_id: string };
+type UserRow = Omit<User, "user_id"> & { user_id: string };
 
 function mapUser(r: UserRow): User {
   return { ...r, user_id: asUserId(r.user_id) };
 }
 
 export async function getUserById(id: UserID): Promise<User | null> {
-  const row = await one<UserRow>('SELECT * FROM users WHERE user_id = $1', [id]);
+  const row = await one<UserRow>("SELECT * FROM users WHERE user_id = $1", [
+    id,
+  ]);
   return row ? mapUser(row) : null;
 }
 
 export async function getUserByEmail(email: string): Promise<User | null> {
-  const row = await one<UserRow>('SELECT * FROM users WHERE email = $1', [email]);
+  const row = await one<UserRow>("SELECT * FROM users WHERE email = $1", [
+    email,
+  ]);
+  return row ? mapUser(row) : null;
+}
+
+export async function getUserByUsername(
+  user_name: string,
+): Promise<User | null> {
+  const row = await one<UserRow>("SELECT * FROM users WHERE user_name = $1", [
+    user_name,
+  ]);
   return row ? mapUser(row) : null;
 }
 
 export async function insertUser(
-  input: Omit<User, 'user_id' | 'created_at'>,
+  input: Omit<User, "user_id" | "created_at">,
 ): Promise<User> {
   const row = await one<UserRow>(
     `INSERT INTO users
        (user_id, user_name, email, password_hash, age, gender, institution, education_level)
-     VALUES (uuid_generate_v4(), $1, $2, $3, $4, $5, $6, $7)
+     VALUES (gen_random_uuid(), $1, $2, $3, $4, $5, $6, $7)
      RETURNING *`,
-    [input.user_name, input.email, input.password_hash,
-     input.age, input.gender, input.institution, input.education_level],
+    [
+      input.user_name,
+      input.email,
+      input.password_hash,
+      input.age,
+      input.gender,
+      input.institution,
+      input.education_level,
+    ],
   );
-  if (!row) throw new Error('insertUser: no row returned');
+  if (!row) throw new DatabaseError("insertUser: no row returned");
   return mapUser(row);
 }


### PR DESCRIPTION
## Summary

Refines and stabilizes the typed Postgres query layer and auth routes. This PR hardens database error boundaries, strictly enforces branded types, and successfully integrates the incoming WebSocket and rate-limiting infrastructure.

- **Query Layer Standardization:** Replaced manual `as XID` type casting across all query modules with strict brand constructors (e.g., `asUserId`, `asQuestionId`) from `src/lib/db-brands.ts`.
- **Schema & DB Generation:** Migrated default UUID generation throughout the schema and insert queries from `uuid_generate_v4()` to the Postgres-native `gen_random_uuid()`.
- **Auth Route Decoupling:** Abstracted raw `one<User>` DB calls out of the login/signup REST routes, delegating data fetching entirely to strongly-typed query functions (`getUserByEmail`, `getUserByUsername`, `insertUser`).
- **Security & Error Hardening:** 
  - Introduced `DatabaseError` for unhandled query failures. 
  - Secured `errorToResponse` to log unknown errors server-side rather than leaking raw DB/infrastructure messages to the client.
  - Removed the unsafe development fallback for `JWT_SECRET`.
- **Merge Integration:** Resolved conflicts with the real-time branch, successfully preserving the newly introduced `socket.io` initialization (`server.ts`, `socket.ts`) and the `/api` rate-limiting `middleware.ts`.