### PR TITLE
feat: create base for profile UI; fix dark mode

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@custom-variant dark (&:where(.dark, .dark *));
 
 :root {
   /* light mode */

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -5,11 +5,15 @@ import { useEffect, useState, useRef } from "react";
 import ThemeToggle from "@/components/ThemeToggle";
 import { useRouter } from "next/navigation";
 import { Settings, LogOut, Edit2 } from "lucide-react";
+import ProfileMetricCard from "@/components/profile/ProfileMetricCard";
+import ProfileTabs from "@/components/profile/ProfileTabs";
+import ProfilePostCard from "@/components/profile/ProfilePostCard";
 
 export default function ProfilePage() {
   const [userName, setUserName] = useState("Loading...");
   const [subtitle, setSubtitle] = useState("Loading...");
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+  const [activeTab, setActiveTab] = useState("Tutorials");
   const settingsRef = useRef<HTMLDivElement>(null);
   const router = useRouter();
 
@@ -50,28 +54,45 @@ export default function ProfilePage() {
     router.push("/login");
   };
 
+  const tabs = ["Tutorials", "Questions asked", "Answers given"];
+
   return (
     <div className="flex min-h-[calc(100vh-1.5rem)] bg-background flex-col m-3 rounded-xl border border-border overflow-hidden relative">
-      <div className="flex flex-col p-8 gap-8 w-full max-w-5xl mx-auto flex-1">
-        <div className="flex flex-col sm:flex-row items-center justify-between gap-4">
-          <div className="flex flex-row items-center gap-6">
-            <div className="p-1 bg-surface border border-border rounded-full shadow-sm">
+      <TopNavBar />
+      <div
+        id="profile-content-container"
+        className="flex flex-col p-8 gap-8 w-full mx-auto flex-1 bg-surface"
+      >
+        <div
+          id="profile-header"
+          className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4"
+        >
+          <div id="basic-details" className="flex flex-row items-center gap-6">
+            <div className="p-1 bg-surface border border-border rounded-full shadow-sm shrink-0">
               <img
                 src="https://static.wikia.nocookie.net/chiikawa/images/a/a0/Momonga.png/revision/latest?cb=20240921205329"
                 alt="Profile"
-                className="w-24 h-24 rounded-full object-cover"
+                className="w-20 h-20 sm:w-24 sm:h-24 rounded-full object-cover"
               />
             </div>
             <div className="flex flex-col">
               <h1 className="text-2xl sm:text-3xl font-bold font-sora text-text">
                 {userName}
               </h1>
-              <p className="text-muted text-md sm:text-lg">{subtitle}</p>
+              <p className="text-muted text-sm sm:text-base mt-1">{subtitle}</p>
             </div>
           </div>
 
-          <div className="flex flex-row items-center gap-4">
-            <button className="flex items-center gap-2 px-5 py-2.5 bg-surface hover:bg-surface-hover border border-border rounded-xl text-text font-medium transition-colors shadow-sm">
+          <div
+            id="profile-actions"
+            className="flex flex-row items-center gap-2"
+          >
+            <button
+              className="flex items-center gap-2 px-5 py-2.5 bg-surface hover:bg-surface-hover 
+            border border-border rounded-xl text-text font-medium shadow-sm text-sm
+            cursor-pointer hover:bg-muted/5 transition-all duration-200
+            "
+            >
               <Edit2 size={16} />
               <span>Edit profile</span>
             </button>
@@ -79,13 +100,16 @@ export default function ProfilePage() {
             <div className="relative" ref={settingsRef}>
               <button
                 onClick={() => setIsSettingsOpen(!isSettingsOpen)}
-                className={`p-2.5 border border-border rounded-xl text-text hover:bg-surface-hover transition-colors shadow-sm flex items-center justify-center ${isSettingsOpen ? "bg-surface-hover" : "bg-surface"}`}
+                className={`p-2.5 border border-border rounded-xl text-text hover:bg-surface-hover 
+                  shadow-sm flex items-center justify-center 
+                  cursor-pointer hover:bg-muted/5 transition-all duration-200
+                  ${isSettingsOpen ? "bg-surface-hover" : "bg-surface"}`}
               >
                 <Settings size={20} />
               </button>
 
               {isSettingsOpen && (
-                <div className="absolute right-0 mt-2 w-56 bg-surface border border-border rounded-xl shadow-lg z-10 flex flex-col p-1 animate-in fade-in slide-in-from-top-2 duration-200">
+                <div className="absolute right-0 mt-2 w-56 bg-surface border border-border rounded-xl shadow-lg z-10 flex flex-col p-1 duration-200">
                   <div className="px-3 py-3 flex items-center justify-between text-sm font-medium text-text border-b border-border">
                     <span>Dark Mode</span>
                     <div className="scale-90 origin-right">
@@ -94,7 +118,9 @@ export default function ProfilePage() {
                   </div>
                   <button
                     onClick={handleLogout}
-                    className="px-3 py-3 w-full flex items-center gap-2 text-left text-sm font-medium text-red-500 hover:bg-red-50 dark:hover:bg-red-950/30 rounded-lg mt-1 transition-colors"
+                    className="px-3 py-3 w-full flex items-center gap-2 text-left text-sm font-medium 
+                    text-red-500 hover:bg-red-100/50 rounded-lg mt-1 transition-colors
+                    cursor-pointer"
                   >
                     <LogOut size={16} />
                     <span>Logout</span>
@@ -102,6 +128,50 @@ export default function ProfilePage() {
                 </div>
               )}
             </div>
+          </div>
+        </div>
+
+        <div id="profile-metrics" className="flex flex-row flex-wrap gap-4 w-full">
+          <ProfileMetricCard value="N/A" label="Questions" />
+          <ProfileMetricCard value="N/A" label="Answers" />
+          <ProfileMetricCard value="N/A" label="Likes Given" />
+          <ProfileMetricCard value="N/A" label="Rating" variant="success" />
+          <ProfileMetricCard value="N/A" label="Engagement" variant="warning" />
+        </div>
+
+        <div id="profile-content" className="flex flex-col gap-6 w-full">
+          <ProfileTabs
+            tabs={tabs}
+            activeTab={activeTab}
+            onTabChange={setActiveTab}
+          />
+          
+          <div className="flex flex-col gap-4">
+             {/* Mock Tutorials - as per image */}
+             {activeTab === "Tutorials" && (
+              <>
+                 <ProfilePostCard 
+                   title="N/A"
+                   type="Tutorial"
+                   timeAgo="N/A"
+                   upvotes="N/A"
+                   comments="N/A"
+                 />
+                 <ProfilePostCard 
+                   title="N/A"
+                   type="Tutorial"
+                   timeAgo="N/A"
+                   upvotes="N/A"
+                   comments="N/A"
+                 />
+              </>
+             )}
+             
+             {activeTab !== "Tutorials" && (
+                <div className="text-muted text-sm py-4 text-center">
+                  No {activeTab.toLowerCase()} yet.
+                </div>
+             )}
           </div>
         </div>
       </div>

--- a/src/app/questions/page.tsx
+++ b/src/app/questions/page.tsx
@@ -4,7 +4,6 @@ import TopNavBar from "@/components/navigation/topnavbar";
 import { useState } from "react";
 
 export default function QuestionsPage() {
-  const [isSideBarCollapsed, setIsSideBarCollapsed] = useState(false);
   return (
     <div
       id="questionspage-container"

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -45,7 +45,7 @@ export default function ThemeToggle({ className }: ThemeToggleProps) {
   return (
     <button
       onClick={toggleTheme}
-      className={`p-2 rounded-full bg-surface border border-border shadow-sm hover:shadow-md cursor-pointer transition-all duration-300 z-50 text-text flex items-center justify-center group ${className || ''}`}
+      className={`p-2 rounded-full bg-surface border border-border shadow-sm hover:shadow-md cursor-pointer transition-all duration-300 z-50 text-text flex items-center justify-center group ${className || ""}`}
       aria-label="Toggle theme"
     >
       {theme === "light" ? (

--- a/src/components/navigation/topnavbar.tsx
+++ b/src/components/navigation/topnavbar.tsx
@@ -20,8 +20,9 @@ export default function TopNavBar({}: TopNavBarProps) {
         if (user) {
           setUserName(user.user_name || "User");
           const edu = user.education_level || "Undergraduate";
-          // Capitalize first letter and replace underscores
-          setEducation(edu.charAt(0).toUpperCase() + edu.slice(1).replace("_", " "));
+          setEducation(
+            edu.charAt(0).toUpperCase() + edu.slice(1).replace("_", " "),
+          );
         }
       } catch (e) {
         console.error("Failed to parse user from localStorage", e);
@@ -58,29 +59,32 @@ export default function TopNavBar({}: TopNavBarProps) {
         className="flex flex-row gap-3 absolute left-1/2 -translate-x-1/2"
       >
         <Link href="/home">
-          <TextButton 
-            label="Home" 
-            {...defaultTextButtonConfig} 
-            isSelected={pathname === "/home"} 
+          <TextButton
+            label="Home"
+            {...defaultTextButtonConfig}
+            isSelected={pathname === "/home"}
           />
         </Link>
         <Link href="/tutorials">
-          <TextButton 
-            label="Tutorials" 
-            {...defaultTextButtonConfig} 
-            isSelected={pathname === "/tutorials"} 
+          <TextButton
+            label="Tutorials"
+            {...defaultTextButtonConfig}
+            isSelected={pathname === "/tutorials"}
           />
         </Link>
         <Link href="/questions">
-          <TextButton 
-            label="Questions" 
-            {...defaultTextButtonConfig} 
-            isSelected={pathname === "/questions"} 
+          <TextButton
+            label="Questions"
+            {...defaultTextButtonConfig}
+            isSelected={pathname === "/questions"}
           />
         </Link>
       </div>
 
-      <div id="rightmost-container" className="flex flex-row gap-1 cursor-pointer">
+      <div
+        id="rightmost-container"
+        className="flex flex-row gap-1 cursor-pointer"
+      >
         <Link href="/profile" className="flex flex-row gap-1 items-center">
           <div id="profile-container" className="items-center flex">
             <img
@@ -93,7 +97,7 @@ export default function TopNavBar({}: TopNavBarProps) {
           </div>
           <div
             id="profile-details-container"
-            className="flex-col font-inter p-2 max-w-30 justify-center hidden sm:flex"
+            className="flex-col font-inter p-2 max-w-30 justify-center hidden sm:flex hover:bg-border/50 transition-all duration-200 rounded-lg"
           >
             <p className="text-md text-text font-medium overflow-hidden leading-tight">
               {userName}
@@ -107,4 +111,3 @@ export default function TopNavBar({}: TopNavBarProps) {
     </div>
   );
 }
-

--- a/src/components/profile/ProfileMetricCard.tsx
+++ b/src/components/profile/ProfileMetricCard.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+
+interface ProfileMetricCardProps {
+  value: string | number;
+  label: string;
+  variant?: "default" | "success" | "warning";
+}
+
+export default function ProfileMetricCard({
+  value,
+  label,
+  variant = "default",
+}: ProfileMetricCardProps) {
+  let bgColor = "bg-surface border border-border";
+  let textColor = "text-text";
+  let labelColor = "text-muted";
+
+  if (variant === "success") {
+    bgColor = "bg-green-100 dark:bg-green-900/20 border border-green-200 dark:border-green-800";
+    textColor = "text-green-900 dark:text-green-300";
+    labelColor = "text-green-700 dark:text-green-400";
+  } else if (variant === "warning") {
+    bgColor = "bg-yellow-100 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800";
+    textColor = "text-yellow-900 dark:text-yellow-300";
+    labelColor = "text-yellow-700 dark:text-yellow-400";
+  } else {
+    bgColor = "bg-muted/5 border border-transparent";
+  }
+
+  return (
+    <div
+      className={`flex flex-col items-center justify-center p-4 rounded-xl flex-1 min-w-[120px] ${bgColor}`}
+    >
+      <span className={`text-2xl font-bold font-sora ${textColor}`}>
+        {value}
+      </span>
+      <span className={`text-xs mt-1 ${labelColor}`}>{label}</span>
+    </div>
+  );
+}

--- a/src/components/profile/ProfilePostCard.tsx
+++ b/src/components/profile/ProfilePostCard.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { ArrowUp, MessageSquare } from "lucide-react";
+
+interface ProfilePostCardProps {
+  title: string;
+  type: string;
+  timeAgo: string;
+  upvotes: number | string;
+  comments: number | string;
+  onEdit?: () => void;
+  onDelete?: () => void;
+}
+
+export default function ProfilePostCard({
+  title,
+  type,
+  timeAgo,
+  upvotes,
+  comments,
+  onEdit,
+  onDelete,
+}: ProfilePostCardProps) {
+  return (
+    <div className="flex flex-col p-5 bg-surface border border-border rounded-xl shadow-sm gap-3 hover:border-primary-300 transition-colors duration-200">
+      <h3 className="text-base font-semibold font-sora text-text">{title}</h3>
+      <div className="flex flex-row items-center gap-3">
+        <span className="px-2 py-0.5 text-xs font-medium bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400 rounded-md">
+          {type}
+        </span>
+        <span className="text-xs text-muted">{timeAgo}</span>
+      </div>
+      <div className="flex flex-row items-center gap-4 mt-1">
+        <div className="flex items-center gap-1 text-muted text-xs font-medium">
+          <ArrowUp size={14} />
+          <span>{upvotes}</span>
+        </div>
+        <div className="flex items-center gap-1 text-muted text-xs font-medium">
+          <MessageSquare size={14} />
+          <span>{comments}</span>
+        </div>
+        <div className="flex-1" />
+        <div className="flex items-center gap-3 text-xs font-medium">
+          <button
+            onClick={onEdit}
+            className="text-muted hover:text-text transition-colors"
+          >
+            Edit
+          </button>
+          <button
+            onClick={onDelete}
+            className="text-red-500 hover:text-red-600 transition-colors"
+          >
+            Delete
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/profile/ProfileTabs.tsx
+++ b/src/components/profile/ProfileTabs.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+
+interface ProfileTabsProps {
+  tabs: string[];
+  activeTab: string;
+  onTabChange: (tab: string) => void;
+}
+
+export default function ProfileTabs({
+  tabs,
+  activeTab,
+  onTabChange,
+}: ProfileTabsProps) {
+  return (
+    <div className="flex flex-row gap-6 border-b border-border w-full">
+      {tabs.map((tab) => (
+        <button
+          key={tab}
+          onClick={() => onTabChange(tab)}
+          className={`pb-3 text-sm font-medium transition-colors relative ${
+            activeTab === tab
+              ? "text-text"
+              : "text-muted hover:text-text"
+          }`}
+        >
+          {tab}
+          {activeTab === tab && (
+            <div className="absolute bottom-[-1px] left-0 w-full h-[2px] bg-text rounded-t-full" />
+          )}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,8 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
-  content: [
-    "./src/**/*.{js,ts,jsx,tsx,mdx}",
-  ],
+  content: ["./src/**/*.{js,ts,jsx,tsx,mdx}"],
   theme: {
     extend: {},
   },


### PR DESCRIPTION
- refactored the UI for the profile page to be full width
- reduced the size of the progile details
- create 3 new components for the profile's content - all current N/A since there is no data:
	- profileMetricCard for showcasing various user metrics
	- profilePostCard as a summary for the user's interacted posts
	- profileTabs for choosing different tabs
- modifications to tailwind config to fix issue with system detecting as dark mode always in the machine