### PR TITLE
feat/tutorial creation linked to questions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ yarn-error.log*
 # vercel
 .vercel
 
+# local file storage uploads
+/uploads
+
 # typescript
 *.tsbuildinfo
 next-env.d.ts

--- a/database_schema.sql
+++ b/database_schema.sql
@@ -220,6 +220,29 @@ CREATE TABLE tutorial_materials (
 );
 CREATE INDEX idx_tutorial_materials_tutorial_id ON tutorial_materials(tutorial_id);
 
+-- Drop legacy single-question FK on tutorials; questions_tutorials is the only link.
+DROP VIEW IF EXISTS tutorial_stats;
+DROP INDEX IF EXISTS idx_tutorials_question_id;
+ALTER TABLE tutorials DROP COLUMN IF EXISTS question_id;
+
+CREATE VIEW tutorial_stats AS
+SELECT
+  t.tutorial_id,
+  t.user_id,
+  t.title,
+  t.content,
+  t.embedded_video_url,
+  t.created_at,
+  u.user_name,
+  COUNT(DISTINCT i.interaction_id) as total_interactions,
+  COUNT(DISTINCT CASE WHEN i.interaction_type = 'rating' THEN i.interaction_id END) as rating_count,
+  AVG(CASE WHEN i.interaction_type = 'rating' THEN i.value END) as avg_rating
+FROM tutorials t
+JOIN users u ON t.user_id = u.user_id
+LEFT JOIN interactions i ON t.tutorial_id = i.tutorial_id
+WHERE t.deleted_at IS NULL
+GROUP BY t.tutorial_id, t.user_id, t.title, t.content, t.embedded_video_url, t.created_at, u.user_name;
+
 SELECT table_name
 FROM information_schema.tables
 WHERE table_schema = 'public'

--- a/database_schema.sql
+++ b/database_schema.sql
@@ -197,7 +197,28 @@ SELECT
 FROM tutorials t
 JOIN users u ON t.user_id = u.user_id
 LEFT JOIN interactions i ON t.tutorial_id = i.tutorial_id
+WHERE t.deleted_at IS NULL
 GROUP BY t.tutorial_id, t.user_id, t.question_id, t.title, t.content, t.embedded_video_url, t.created_at, u.user_name;
+
+-- ============================================
+-- MIGRATIONS
+-- ============================================
+
+-- Soft delete support for tutorials
+ALTER TABLE tutorials ADD COLUMN deleted_at TIMESTAMP WITH TIME ZONE DEFAULT NULL;
+CREATE INDEX idx_tutorials_deleted_at ON tutorials(deleted_at) WHERE deleted_at IS NOT NULL;
+
+-- Tutorial materials (uploaded files) table
+CREATE TABLE tutorial_materials (
+  material_id  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tutorial_id  UUID NOT NULL REFERENCES tutorials(tutorial_id) ON DELETE CASCADE,
+  file_name    VARCHAR(255) NOT NULL,
+  storage_key  VARCHAR(1000) NOT NULL,
+  mime_type    VARCHAR(100) NOT NULL,
+  size_bytes   BIGINT NOT NULL,
+  uploaded_at  TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX idx_tutorial_materials_tutorial_id ON tutorial_materials(tutorial_id);
 
 SELECT table_name
 FROM information_schema.tables

--- a/database_schema.sql
+++ b/database_schema.sql
@@ -205,11 +205,11 @@ GROUP BY t.tutorial_id, t.user_id, t.question_id, t.title, t.content, t.embedded
 -- ============================================
 
 -- Soft delete support for tutorials
-ALTER TABLE tutorials ADD COLUMN deleted_at TIMESTAMP WITH TIME ZONE DEFAULT NULL;
-CREATE INDEX idx_tutorials_deleted_at ON tutorials(deleted_at) WHERE deleted_at IS NOT NULL;
+ALTER TABLE tutorials ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP WITH TIME ZONE DEFAULT NULL;
+CREATE INDEX IF NOT EXISTS idx_tutorials_deleted_at ON tutorials(deleted_at) WHERE deleted_at IS NOT NULL;
 
 -- Tutorial materials (uploaded files) table
-CREATE TABLE tutorial_materials (
+CREATE TABLE IF NOT EXISTS tutorial_materials (
   material_id  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   tutorial_id  UUID NOT NULL REFERENCES tutorials(tutorial_id) ON DELETE CASCADE,
   file_name    VARCHAR(255) NOT NULL,
@@ -218,7 +218,7 @@ CREATE TABLE tutorial_materials (
   size_bytes   BIGINT NOT NULL,
   uploaded_at  TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
-CREATE INDEX idx_tutorial_materials_tutorial_id ON tutorial_materials(tutorial_id);
+CREATE INDEX IF NOT EXISTS idx_tutorial_materials_tutorial_id ON tutorial_materials(tutorial_id);
 
 -- Drop legacy single-question FK on tutorials; questions_tutorials is the only link.
 DROP VIEW IF EXISTS tutorial_stats;

--- a/docs/database-queries-and-transactions.md
+++ b/docs/database-queries-and-transactions.md
@@ -1,0 +1,98 @@
+# Database Queries & Transactions
+
+All server-side database access is centralized in `src/lib/db.ts`. To ensure Next.js hot-module replacement (HMR) doesn't exhaust our connection limits, and to safely handle multi-step database writes, we use a **Transaction-Aware Repository Pattern**.
+
+## Core Query Functions
+
+We wrap `pg`'s default query methods to handle type-casting and connection scoping.
+
+|**Function**|**Scope**|**Yields**|**Use Case**|
+|---|---|---|---|
+|`q`|General Pool|`T[]`|Standalone queries returning multiple rows.|
+|`one`|General Pool|`T \| null`|Standalone queries returning a single row.|
+|`qOn`|Specific Client|`T[]`|Inside transactions returning multiple rows.|
+|`oneOn`|Specific Client|`T \| null`|Inside transactions returning a single row.|
+
+Using the general pool (`q`, `one`) checks out a random connection, runs the query, and immediately releases it. Using a specific client (`qOn`, `oneOn`) locks the query to a dedicated connection — which is mandatory for transactions.
+
+## `withTransaction`
+
+The single function that orchestrates database transactions. It checks out a dedicated `PoolClient`, initiates a `BEGIN` statement, executes your callback, and handles `COMMIT` or `ROLLBACK` automatically.
+
+TypeScript
+
+```
+import { withTransaction } from "@/lib/db";
+
+const result = await withTransaction(async (client) => {
+  // All queries inside this block MUST use the injected `client`
+});
+```
+
+If any error is thrown inside the callback, `withTransaction` will issue a `ROLLBACK`. If the operation fails entirely, it is treated as a `DatabaseError` (HTTP 500) and caught by our centralized error handling.
+
+## Usage Patterns
+
+### Standalone Queries — Auto-pooling
+
+Use this pattern for simple API routes or data-fetching functions where only a single database operation is required. The function manages its own connection to the pool.
+
+TypeScript
+
+```
+export async function getQuestionById(id: QuestionID): Promise<Questions | null> {
+  // `one` automatically grabs a connection and releases it
+  const row = await one<QuestionRow>(
+    "SELECT * FROM questions WHERE question_id = $1",
+    [id]
+  );
+  return row ? mapQuestion(row) : null;
+}
+```
+
+### Multi-step Transactions — Client Injection
+
+Use this pattern when multiple database operations must succeed or fail together (e.g., deducting credits and inserting a row). You must inject the `client` provided by `withTransaction` into every subsequent repository call.
+
+TypeScript
+
+```
+export async function createQuestionAndDeductCredits(userId: UserID, content: string) {
+  return await withTransaction(async (client) => {
+    // 1. Deduct credits using the shared transaction client
+    await deductUserCredits(userId, 10, client);
+
+    // 2. Insert the question using the EXACT SAME client
+    const newQuestion = await insertQuestion(userId, content, "general", client);
+
+    return newQuestion;
+  });
+}
+```
+
+**Rule of thumb:** If a repository function requires multiple steps, wrap it in `withTransaction`. If a higher-level business logic function calls multiple repository functions, wrap the _business logic_ in `withTransaction` and pass the client down.
+
+## Writing Repository Functions — The Optional Client
+
+To keep our codebase DRY, we do not write separate functions for "transaction" and "non-transaction" queries.
+
+When adding a new database function to the repository, **always add `client?: PoolClient` as the final parameter** and use a ternary operator to switch between `qOn` and `q`.
+
+TypeScript
+
+```
+export async function updateRecord(
+  id: string, 
+  client?: PoolClient // <-- Always optional, always last
+): Promise<Record | null> {
+  const sql = "UPDATE records SET updated_at = now() WHERE id = $1 RETURNING *";
+  
+  const row = client 
+    ? await oneOn<RecordRow>(client, sql, [id]) 
+    : await one<RecordRow>(sql, [id]);
+    
+  return row ? mapRecord(row) : null;
+}
+```
+
+By doing this, the function can gracefully handle standalone execution in a standard route handler, or participate safely in a broader transaction when a client is provided.

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -79,6 +79,23 @@ export function withAuth(handler: RouteHandler) {
 
 **Rule of thumb:** use `throw` + single `catch` when you own the whole execution path. Use early returns when the function may not reach the main logic at all.
 
+### Compensating cleanup — `console.error`, not error brands
+
+When an operation fails partway through and you need to undo a prior side-effect (e.g. a storage write before a DB insert), the *cleanup* failure is a different beast from the *primary* failure. The primary failure shapes the HTTP response; the cleanup failure is an internal, operator-only concern — there's no caller to react to it, and you must not let it mask the original error.
+
+Don't brand the cleanup failure as an `AppError`. Brands exist to drive `errorToResponse`, and the cleanup error never reaches that boundary (you're swallowing it on purpose so the original throws through). Log it with `console.error` and a tagged prefix so it's greppable in production logs.
+
+```ts
+const material = await insertTutorialMaterial({ ... }).catch(async (insertErr) => {
+  await storage
+    .delete(key)
+    .catch((cleanupErr) => console.error("[Orphan Cleanup]", cleanupErr));
+  throw insertErr;
+});
+```
+
+The original `insertErr` rethrows into the outer `catch` and gets converted to a response by `errorToResponse` exactly as if no cleanup had happened.
+
 ## Adding a New Error Class
 
 Add it to `src/lib/errors.ts` following the existing pattern. Only add a new class if no existing one fits the semantics — check the table above first.

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -1,0 +1,92 @@
+# Error Handling
+
+All server-side error handling is centralized in `src/lib/errors.ts`.
+
+## Error Classes
+
+Every error in the API extends `AppError`, which carries an HTTP status code and a machine-readable `code` string alongside the human-readable message.
+
+| Class | Status | Code |
+|---|---|---|
+| `ValidationError` | 400 | `VALIDATION_ERROR` |
+| `AuthError` | 401 | `AUTH_ERROR` |
+| `NotFoundError` | 404 | `NOT_FOUND` |
+| `ConflictError` | 409 | `CONFLICT` |
+| `RateLimitError` | 429 | `RATE_LIMIT_EXCEEDED` |
+| `DatabaseError` | 500 | `DATABASE_ERROR` |
+
+All responses produced by these classes share the same shape:
+
+```json
+{ "error": "<message>", "code": "<CODE>" }
+```
+
+Unhandled errors (anything not extending `AppError`) are caught by `errorToResponse`, logged server-side with `[Unhandled Error]`, and returned as a generic 500 with `code: "INTERNAL_ERROR"` — internal details are never leaked to the client.
+
+## `errorToResponse`
+
+The single function that converts any thrown value into a `NextResponse`. Always use this instead of constructing `NextResponse.json(...)` manually for error cases.
+
+```ts
+import { errorToResponse } from "@/lib/errors";
+
+return errorToResponse(error); // handles AppError subclasses and unknowns
+```
+
+## Usage Patterns
+
+### Route handlers — `throw` as control flow
+
+Use this pattern for API route files (`route.ts`). Wrap the entire happy path in one `try` block; throw typed errors anywhere inside it. A single `catch` at the bottom delegates to `errorToResponse`.
+
+```ts
+export async function POST(request: NextRequest) {
+  try {
+    const { email, password } = await request.json();
+
+    if (!email || !password) throw new ValidationError("Email and password are required");
+
+    const user = await getUserByEmail(email);
+    if (!user) throw new AuthError();
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    return errorToResponse(error);
+  }
+}
+```
+
+### Middleware / guards — early return
+
+Use this pattern for wrapper functions that gate access before reaching a handler (e.g. `withAuth`). Pre-condition failures return early with `errorToResponse(new SomeError(...))` directly; a narrow `try/catch` is used only where a third-party call can throw.
+
+```ts
+export function withAuth(handler: RouteHandler) {
+  return async (req: NextRequest): Promise<NextResponse> => {
+    if (!authHeader?.startsWith("Bearer ")) {
+      return errorToResponse(new AuthError("Unauthorized"));
+    }
+
+    try {
+      const payload = jwt.verify(token, JWT_SECRET);
+      return handler(req as AuthedRequest);
+    } catch {
+      return errorToResponse(new AuthError("Invalid token"));
+    }
+  };
+}
+```
+
+**Rule of thumb:** use `throw` + single `catch` when you own the whole execution path. Use early returns when the function may not reach the main logic at all.
+
+## Adding a New Error Class
+
+Add it to `src/lib/errors.ts` following the existing pattern. Only add a new class if no existing one fits the semantics — check the table above first.
+
+```ts
+export class PaymentError extends AppError {
+  constructor(message = "Payment failed") {
+    super(message, 402, "PAYMENT_ERROR");
+  }
+}
+```

--- a/src/app/api/cron/purge-tutorials/route.ts
+++ b/src/app/api/cron/purge-tutorials/route.ts
@@ -1,0 +1,45 @@
+import { q } from "@/lib/db";
+import { AuthError, errorToResponse } from "@/lib/errors";
+import { hardDeleteExpiredTutorials } from "@/lib/queries/tutorials";
+import { getStorage } from "@/lib/storage";
+import { NextRequest, NextResponse } from "next/server";
+
+const RETENTION_DAYS = 30;
+
+export async function POST(request: NextRequest) {
+  try {
+    const secret = process.env.CRON_SECRET;
+    if (!secret) {
+      throw new AuthError("CRON_SECRET not configured");
+    }
+
+    const authHeader = request.headers.get("authorization");
+    if (authHeader !== `Bearer ${secret}`) {
+      throw new AuthError("Unauthorized");
+    }
+
+    const expiredKeys = await q<{ storage_key: string }>(
+      `SELECT m.storage_key
+       FROM tutorial_materials m
+       JOIN tutorials t ON t.tutorial_id = m.tutorial_id
+       WHERE t.deleted_at IS NOT NULL
+         AND t.deleted_at < now() - ($1 || ' days')::interval`,
+      [RETENTION_DAYS],
+    );
+
+    const storage = getStorage();
+    for (const { storage_key } of expiredKeys) {
+      try {
+        await storage.delete(storage_key);
+      } catch (err) {
+        console.error("[purge-tutorials] file delete failed", storage_key, err);
+      }
+    }
+
+    const deleted = await hardDeleteExpiredTutorials(RETENTION_DAYS);
+
+    return NextResponse.json({ deleted, files_removed: expiredKeys.length });
+  } catch (error) {
+    return errorToResponse(error);
+  }
+}

--- a/src/app/api/files/[...key]/route.ts
+++ b/src/app/api/files/[...key]/route.ts
@@ -1,6 +1,8 @@
 import { AuthError, errorToResponse, NotFoundError } from "@/lib/errors";
 import { readLocalFile, verifyFileToken } from "@/lib/storage/local";
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
+
+type RouteCtx = { params: Promise<{ key: string[] }> };
 
 const MIME_BY_EXT: Record<string, string> = {
   pdf: "application/pdf",
@@ -16,10 +18,7 @@ const MIME_BY_EXT: Record<string, string> = {
   pptx: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
 };
 
-export async function GET(
-  req: Request,
-  { params }: { params: Promise<{ key: string[] }> },
-) {
+export async function GET(req: NextRequest, { params }: RouteCtx) {
   try {
     const { key } = await params;
     const joined = key.map(decodeURIComponent).join("/");

--- a/src/app/api/files/[...key]/route.ts
+++ b/src/app/api/files/[...key]/route.ts
@@ -1,0 +1,43 @@
+import { errorToResponse, NotFoundError } from "@/lib/errors";
+import { readLocalFile } from "@/lib/storage/local";
+import { NextResponse } from "next/server";
+
+const MIME_BY_EXT: Record<string, string> = {
+  pdf: "application/pdf",
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+  mp4: "video/mp4",
+  webm: "video/webm",
+  ogg: "video/ogg",
+  docx: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  pptx: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+};
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ key: string[] }> },
+) {
+  try {
+    const { key } = await params;
+    const joined = key.map(decodeURIComponent).join("/");
+    const result = await readLocalFile(joined);
+    if (!result) throw new NotFoundError("File not found");
+
+    const ext = joined.split(".").pop()?.toLowerCase() ?? "";
+    const mime = MIME_BY_EXT[ext] ?? "application/octet-stream";
+
+    return new NextResponse(new Uint8Array(result.buffer), {
+      status: 200,
+      headers: {
+        "Content-Type": mime,
+        "Content-Length": String(result.size),
+        "Cache-Control": "private, max-age=3600",
+      },
+    });
+  } catch (error) {
+    return errorToResponse(error);
+  }
+}

--- a/src/app/api/files/[...key]/route.ts
+++ b/src/app/api/files/[...key]/route.ts
@@ -1,5 +1,5 @@
-import { errorToResponse, NotFoundError } from "@/lib/errors";
-import { readLocalFile } from "@/lib/storage/local";
+import { AuthError, errorToResponse, NotFoundError } from "@/lib/errors";
+import { readLocalFile, verifyFileToken } from "@/lib/storage/local";
 import { NextResponse } from "next/server";
 
 const MIME_BY_EXT: Record<string, string> = {
@@ -17,12 +17,17 @@ const MIME_BY_EXT: Record<string, string> = {
 };
 
 export async function GET(
-  _req: Request,
+  req: Request,
   { params }: { params: Promise<{ key: string[] }> },
 ) {
   try {
     const { key } = await params;
     const joined = key.map(decodeURIComponent).join("/");
+
+    const token = new URL(req.url).searchParams.get("token");
+    if (!token) throw new AuthError("Missing file URL token");
+    verifyFileToken(joined, token);
+
     const result = await readLocalFile(joined);
     if (!result) throw new NotFoundError("File not found");
 

--- a/src/app/api/tutorial/[tutorialId]/materials/route.ts
+++ b/src/app/api/tutorial/[tutorialId]/materials/route.ts
@@ -1,0 +1,46 @@
+import { withAuth, type AuthedRequest } from "@/lib/auth";
+import { asTutorialId } from "@/lib/db-brands";
+import { AuthError, errorToResponse, NotFoundError } from "@/lib/errors";
+import { listMaterialsForTutorial } from "@/lib/queries/tutorial-materials";
+import { getTutorialById } from "@/lib/queries/tutorials";
+import { DEFAULT_URL_TTL_SECONDS, getStorage } from "@/lib/storage";
+import { NextRequest, NextResponse } from "next/server";
+
+type RouteCtx = { params: Promise<{ tutorialId: string }> };
+
+export const GET = (req: NextRequest, ctx: RouteCtx) =>
+  withAuth(async (authedReq: AuthedRequest) => {
+    try {
+      const { tutorialId } = await ctx.params;
+      const tid = asTutorialId(tutorialId);
+
+      const tutorial = await getTutorialById(tid);
+      if (!tutorial) throw new NotFoundError("Tutorial not found");
+      if (tutorial.user_id !== authedReq.userId) {
+        throw new AuthError("Forbidden");
+      }
+
+      const storage = getStorage();
+      const ttl = DEFAULT_URL_TTL_SECONDS;
+      const expires_at = new Date(Date.now() + ttl * 1000).toISOString();
+
+      const rows = await listMaterialsForTutorial(tid);
+      const materials = await Promise.all(
+        rows.map(async (m) => ({
+          ...m,
+          url: await storage.getUrl(m.storage_key, { expiresIn: ttl }),
+          expires_at,
+        })),
+      );
+
+      return NextResponse.json(
+        { materials },
+        {
+          status: 200,
+          headers: { "Cache-Control": `private, max-age=${ttl}` },
+        },
+      );
+    } catch (error) {
+      return errorToResponse(error);
+    }
+  })(req);

--- a/src/app/api/tutorial/[tutorialId]/materials/route.ts
+++ b/src/app/api/tutorial/[tutorialId]/materials/route.ts
@@ -1,6 +1,6 @@
 import { withAuth, type AuthedRequest } from "@/lib/auth";
 import { asTutorialId } from "@/lib/db-brands";
-import { AuthError, errorToResponse, NotFoundError } from "@/lib/errors";
+import { errorToResponse, ForbiddenError, NotFoundError } from "@/lib/errors";
 import { listMaterialsForTutorial } from "@/lib/queries/tutorial-materials";
 import { getTutorialById } from "@/lib/queries/tutorials";
 import { DEFAULT_URL_TTL_SECONDS, getStorage } from "@/lib/storage";
@@ -17,7 +17,7 @@ export const GET = (req: NextRequest, ctx: RouteCtx) =>
       const tutorial = await getTutorialById(tid);
       if (!tutorial) throw new NotFoundError("Tutorial not found");
       if (tutorial.user_id !== authedReq.userId) {
-        throw new AuthError("Forbidden");
+        throw new ForbiddenError();
       }
 
       const storage = getStorage();

--- a/src/app/api/tutorial/[tutorialId]/questions/route.ts
+++ b/src/app/api/tutorial/[tutorialId]/questions/route.ts
@@ -4,6 +4,7 @@ import {
   AuthError,
   errorToResponse,
   NotFoundError,
+  ValidationError,
 } from "@/lib/errors";
 import {
   linkQuestionTutorial,
@@ -38,10 +39,16 @@ export const POST = (req: NextRequest, ctx: RouteCtx) =>
       const qid = asQuestionId(question_id);
       const question = await getQuestionById(qid);
       if (!question) throw new NotFoundError("Question not found");
+      if (question.user_id === authedReq.userId) {
+        throw new ValidationError(
+          "You cannot link a tutorial to your own question",
+        );
+      }
 
-      const links = await linkQuestionTutorial(qid, tutorial.tutorial_id);
+      const { created } = await linkQuestionTutorial(qid, tutorial.tutorial_id);
       return NextResponse.json({
-        linked: links.length > 0,
+        linked: true,
+        created,
         question_id: qid,
         tutorial_id: tutorial.tutorial_id,
       });

--- a/src/app/api/tutorial/[tutorialId]/questions/route.ts
+++ b/src/app/api/tutorial/[tutorialId]/questions/route.ts
@@ -1,0 +1,75 @@
+import { withAuth, type AuthedRequest } from "@/lib/auth";
+import { asQuestionId, asTutorialId } from "@/lib/db-brands";
+import {
+  AuthError,
+  errorToResponse,
+  NotFoundError,
+} from "@/lib/errors";
+import {
+  linkQuestionTutorial,
+  unlinkQuestionTutorial,
+} from "@/lib/queries/questions-tutorials";
+import { getQuestionById } from "@/lib/queries/questions";
+import { getTutorialById } from "@/lib/queries/tutorials";
+import { parseOrThrow } from "@/lib/validation/tutorial";
+import { z } from "zod";
+import { NextRequest, NextResponse } from "next/server";
+
+type RouteCtx = { params: Promise<{ tutorialId: string }> };
+
+const bodySchema = z.object({ question_id: z.uuid() });
+
+async function loadOwnedTutorial(tid: string, userId: string) {
+  const tutorial = await getTutorialById(asTutorialId(tid));
+  if (!tutorial) throw new NotFoundError("Tutorial not found");
+  if (tutorial.user_id !== userId) throw new AuthError("Forbidden");
+  return tutorial;
+}
+
+export const POST = (req: NextRequest, ctx: RouteCtx) =>
+  withAuth(async (authedReq: AuthedRequest) => {
+    try {
+      const { tutorialId } = await ctx.params;
+      const tutorial = await loadOwnedTutorial(tutorialId, authedReq.userId);
+
+      const body = await authedReq.json();
+      const { question_id } = parseOrThrow(bodySchema, body);
+
+      const qid = asQuestionId(question_id);
+      const question = await getQuestionById(qid);
+      if (!question) throw new NotFoundError("Question not found");
+
+      const links = await linkQuestionTutorial(qid, tutorial.tutorial_id);
+      return NextResponse.json({
+        linked: links.length > 0,
+        question_id: qid,
+        tutorial_id: tutorial.tutorial_id,
+      });
+    } catch (error) {
+      return errorToResponse(error);
+    }
+  })(req);
+
+export const DELETE = (req: NextRequest, ctx: RouteCtx) =>
+  withAuth(async (authedReq: AuthedRequest) => {
+    try {
+      const { tutorialId } = await ctx.params;
+      const tutorial = await loadOwnedTutorial(tutorialId, authedReq.userId);
+
+      const body = await authedReq.json();
+      const { question_id } = parseOrThrow(bodySchema, body);
+
+      const qid = asQuestionId(question_id);
+      const question = await getQuestionById(qid);
+      if (!question) throw new NotFoundError("Question not found");
+
+      const removed = await unlinkQuestionTutorial(qid, tutorial.tutorial_id);
+      return NextResponse.json({
+        unlinked: removed.length > 0,
+        question_id: qid,
+        tutorial_id: tutorial.tutorial_id,
+      });
+    } catch (error) {
+      return errorToResponse(error);
+    }
+  })(req);

--- a/src/app/api/tutorial/[tutorialId]/questions/route.ts
+++ b/src/app/api/tutorial/[tutorialId]/questions/route.ts
@@ -1,8 +1,8 @@
 import { withAuth, type AuthedRequest } from "@/lib/auth";
 import { asQuestionId, asTutorialId } from "@/lib/db-brands";
 import {
-  AuthError,
   errorToResponse,
+  ForbiddenError,
   NotFoundError,
   ValidationError,
 } from "@/lib/errors";
@@ -23,7 +23,7 @@ const bodySchema = z.object({ question_id: z.uuid() });
 async function loadOwnedTutorial(tid: string, userId: string) {
   const tutorial = await getTutorialById(asTutorialId(tid));
   if (!tutorial) throw new NotFoundError("Tutorial not found");
-  if (tutorial.user_id !== userId) throw new AuthError("Forbidden");
+  if (tutorial.user_id !== userId) throw new ForbiddenError();
   return tutorial;
 }
 

--- a/src/app/api/tutorial/[tutorialId]/route.ts
+++ b/src/app/api/tutorial/[tutorialId]/route.ts
@@ -1,6 +1,6 @@
 import { withAuth, type AuthedRequest } from "@/lib/auth";
 import { asTutorialId } from "@/lib/db-brands";
-import { AuthError, errorToResponse, NotFoundError } from "@/lib/errors";
+import { errorToResponse, ForbiddenError, NotFoundError } from "@/lib/errors";
 import { questionsForTutorial } from "@/lib/queries/questions-tutorials";
 import {
   getTutorialById,
@@ -44,7 +44,7 @@ export const PUT = (req: NextRequest, ctx: RouteCtx) =>
       const existing = await getTutorialById(id);
       if (!existing) throw new NotFoundError("Tutorial not found");
       if (existing.user_id !== authedReq.userId) {
-        throw new AuthError("Forbidden");
+        throw new ForbiddenError();
       }
 
       const body = await authedReq.json();
@@ -72,7 +72,7 @@ export const DELETE = (req: NextRequest, ctx: RouteCtx) =>
       const existing = await getTutorialById(id);
       if (!existing) throw new NotFoundError("Tutorial not found");
       if (existing.user_id !== authedReq.userId) {
-        throw new AuthError("Forbidden");
+        throw new ForbiddenError();
       }
 
       await softDeleteTutorial(id);

--- a/src/app/api/tutorial/[tutorialId]/route.ts
+++ b/src/app/api/tutorial/[tutorialId]/route.ts
@@ -1,0 +1,83 @@
+import { withAuth, type AuthedRequest } from "@/lib/auth";
+import { asTutorialId } from "@/lib/db-brands";
+import { AuthError, errorToResponse, NotFoundError } from "@/lib/errors";
+import { questionsForTutorial } from "@/lib/queries/questions-tutorials";
+import {
+  getTutorialById,
+  softDeleteTutorial,
+  updateTutorial,
+} from "@/lib/queries/tutorials";
+import {
+  parseOrThrow,
+  updateTutorialSchema,
+  validateVideoUrl,
+} from "@/lib/validation/tutorial";
+import { NextRequest, NextResponse } from "next/server";
+
+type RouteCtx = { params: Promise<{ tutorialId: string }> };
+
+export async function GET(_req: NextRequest, { params }: RouteCtx) {
+  try {
+    const { tutorialId } = await params;
+    const id = asTutorialId(tutorialId);
+
+    const tutorial = await getTutorialById(id);
+    if (!tutorial) throw new NotFoundError("Tutorial not found");
+
+    const links = await questionsForTutorial(id);
+
+    return NextResponse.json({
+      tutorial,
+      linked_question_ids: links.map((l) => l.question_id),
+    });
+  } catch (error) {
+    return errorToResponse(error);
+  }
+}
+
+export const PUT = (req: NextRequest, ctx: RouteCtx) =>
+  withAuth(async (authedReq: AuthedRequest) => {
+    try {
+      const { tutorialId } = await ctx.params;
+      const id = asTutorialId(tutorialId);
+
+      const existing = await getTutorialById(id);
+      if (!existing) throw new NotFoundError("Tutorial not found");
+      if (existing.user_id !== authedReq.userId) {
+        throw new AuthError("Forbidden");
+      }
+
+      const body = await authedReq.json();
+      const parsed = parseOrThrow(updateTutorialSchema, body);
+
+      if (parsed.embedded_video_url) {
+        validateVideoUrl(parsed.embedded_video_url);
+      }
+
+      const updated = await updateTutorial(id, parsed);
+      if (!updated) throw new NotFoundError("Tutorial not found");
+
+      return NextResponse.json({ tutorial: updated });
+    } catch (error) {
+      return errorToResponse(error);
+    }
+  })(req);
+
+export const DELETE = (req: NextRequest, ctx: RouteCtx) =>
+  withAuth(async (authedReq: AuthedRequest) => {
+    try {
+      const { tutorialId } = await ctx.params;
+      const id = asTutorialId(tutorialId);
+
+      const existing = await getTutorialById(id);
+      if (!existing) throw new NotFoundError("Tutorial not found");
+      if (existing.user_id !== authedReq.userId) {
+        throw new AuthError("Forbidden");
+      }
+
+      await softDeleteTutorial(id);
+      return NextResponse.json({ success: true });
+    } catch (error) {
+      return errorToResponse(error);
+    }
+  })(req);

--- a/src/app/api/tutorial/[tutorialId]/upload/route.ts
+++ b/src/app/api/tutorial/[tutorialId]/upload/route.ts
@@ -8,7 +8,7 @@ import {
 } from "@/lib/errors";
 import { insertTutorialMaterial } from "@/lib/queries/tutorial-materials";
 import { getTutorialById } from "@/lib/queries/tutorials";
-import { getStorage } from "@/lib/storage";
+import { DEFAULT_URL_TTL_SECONDS, getStorage } from "@/lib/storage";
 import {
   DOCUMENT_MIMES,
   validateMaterialFile,
@@ -68,10 +68,15 @@ export const PUT = (req: NextRequest, ctx: RouteCtx) =>
         size_bytes: size,
       });
 
+      const ttl = DEFAULT_URL_TTL_SECONDS;
+      const url = await storage.getUrl(key, { expiresIn: ttl });
+      const expires_at = new Date(Date.now() + ttl * 1000).toISOString();
+
       return NextResponse.json(
         {
           ...material,
-          url: await storage.getUrl(key),
+          url,
+          expires_at,
         },
         { status: 201 },
       );

--- a/src/app/api/tutorial/[tutorialId]/upload/route.ts
+++ b/src/app/api/tutorial/[tutorialId]/upload/route.ts
@@ -1,0 +1,81 @@
+import { withAuth, type AuthedRequest } from "@/lib/auth";
+import { asTutorialId } from "@/lib/db-brands";
+import {
+  AuthError,
+  errorToResponse,
+  NotFoundError,
+  ValidationError,
+} from "@/lib/errors";
+import { insertTutorialMaterial } from "@/lib/queries/tutorial-materials";
+import { getTutorialById } from "@/lib/queries/tutorials";
+import { getStorage } from "@/lib/storage";
+import {
+  DOCUMENT_MIMES,
+  validateMaterialFile,
+  validateVideoFile,
+  VIDEO_MIMES,
+} from "@/lib/validation/tutorial";
+import { randomUUID } from "crypto";
+import { NextRequest, NextResponse } from "next/server";
+
+type RouteCtx = { params: Promise<{ tutorialId: string }> };
+
+function sanitizeFileName(name: string): string {
+  return name.replace(/[^A-Za-z0-9._-]/g, "_").slice(0, 200) || "file";
+}
+
+export const PUT = (req: NextRequest, ctx: RouteCtx) =>
+  withAuth(async (authedReq: AuthedRequest) => {
+    try {
+      const { tutorialId } = await ctx.params;
+      const tid = asTutorialId(tutorialId);
+
+      const tutorial = await getTutorialById(tid);
+      if (!tutorial) throw new NotFoundError("Tutorial not found");
+      if (tutorial.user_id !== authedReq.userId) {
+        throw new AuthError("Forbidden");
+      }
+
+      const formData = await authedReq.formData();
+      const fileEntry = formData.get("file");
+      if (!(fileEntry instanceof File)) {
+        throw new ValidationError("Missing 'file' in form data");
+      }
+
+      const mime = fileEntry.type || "application/octet-stream";
+      const size = fileEntry.size;
+
+      if ((VIDEO_MIMES as readonly string[]).includes(mime)) {
+        validateVideoFile(mime, size);
+      } else if ((DOCUMENT_MIMES as readonly string[]).includes(mime)) {
+        validateMaterialFile(mime, size);
+      } else {
+        throw new ValidationError(`Unsupported file type: ${mime}`);
+      }
+
+      const storage = getStorage();
+      const safeName = sanitizeFileName(fileEntry.name);
+      const key = `tutorials/${tid}/${randomUUID()}-${safeName}`;
+      const buffer = Buffer.from(await fileEntry.arrayBuffer());
+
+      await storage.put({ key, buffer, mimeType: mime });
+
+      const material = await insertTutorialMaterial({
+        tutorial_id: tid,
+        file_name: fileEntry.name,
+        storage_key: key,
+        mime_type: mime,
+        size_bytes: size,
+      });
+
+      return NextResponse.json(
+        {
+          ...material,
+          url: storage.getUrl(key),
+        },
+        { status: 201 },
+      );
+    } catch (error) {
+      return errorToResponse(error);
+    }
+  })(req);

--- a/src/app/api/tutorial/[tutorialId]/upload/route.ts
+++ b/src/app/api/tutorial/[tutorialId]/upload/route.ts
@@ -71,7 +71,7 @@ export const PUT = (req: NextRequest, ctx: RouteCtx) =>
       return NextResponse.json(
         {
           ...material,
-          url: storage.getUrl(key),
+          url: await storage.getUrl(key),
         },
         { status: 201 },
       );

--- a/src/app/api/tutorial/[tutorialId]/upload/route.ts
+++ b/src/app/api/tutorial/[tutorialId]/upload/route.ts
@@ -66,6 +66,13 @@ export const PUT = (req: NextRequest, ctx: RouteCtx) =>
         storage_key: key,
         mime_type: mime,
         size_bytes: size,
+      }).catch(async (insertErr) => {
+        await storage
+          .delete(key)
+          .catch((cleanupErr) =>
+            console.error("[Orphan Cleanup]", cleanupErr),
+          );
+        throw insertErr;
       });
 
       const ttl = DEFAULT_URL_TTL_SECONDS;

--- a/src/app/api/tutorial/question-preview/route.ts
+++ b/src/app/api/tutorial/question-preview/route.ts
@@ -1,0 +1,33 @@
+import { asQuestionId } from "@/lib/db-brands";
+import {
+  errorToResponse,
+  NotFoundError,
+  ValidationError,
+} from "@/lib/errors";
+import { getQuestionById } from "@/lib/queries/questions";
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+const queryQuestionId = z.uuid();
+
+export async function GET(request: NextRequest) {
+  try {
+    const raw = request.nextUrl.searchParams.get("questionId");
+    if (!raw) throw new ValidationError("Missing questionId");
+
+    const parsed = queryQuestionId.safeParse(raw);
+    if (!parsed.success) throw new ValidationError("Invalid questionId");
+
+    const question = await getQuestionById(asQuestionId(parsed.data));
+    if (!question) throw new NotFoundError("Question not found");
+
+    return NextResponse.json({
+      question_id: question.question_id,
+      content: question.content,
+      category: question.category,
+      created_at: question.created_at,
+    });
+  } catch (error) {
+    return errorToResponse(error);
+  }
+}

--- a/src/app/api/tutorial/question-preview/route.ts
+++ b/src/app/api/tutorial/question-preview/route.ts
@@ -1,31 +1,27 @@
 import { asQuestionId } from "@/lib/db-brands";
-import {
-  errorToResponse,
-  NotFoundError,
-  ValidationError,
-} from "@/lib/errors";
+import { errorToResponse, NotFoundError, ValidationError } from "@/lib/errors";
 import { getQuestionById } from "@/lib/queries/questions";
+import { parseOrThrow } from "@/lib/validation/tutorial";
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
-
-const queryQuestionId = z.uuid();
 
 export async function GET(request: NextRequest) {
   try {
     const raw = request.nextUrl.searchParams.get("questionId");
     if (!raw) throw new ValidationError("Missing questionId");
 
-    const parsed = queryQuestionId.safeParse(raw);
-    if (!parsed.success) throw new ValidationError("Invalid questionId");
+    const questionId = parseOrThrow(z.uuid(), raw);
 
-    const question = await getQuestionById(asQuestionId(parsed.data));
+    const question = await getQuestionById(asQuestionId(questionId));
     if (!question) throw new NotFoundError("Question not found");
 
     return NextResponse.json({
-      question_id: question.question_id,
-      content: question.content,
-      category: question.category,
-      created_at: question.created_at,
+      question: {
+        question_id: question.question_id,
+        content: question.content,
+        category: question.category,
+        created_at: question.created_at,
+      },
     });
   } catch (error) {
     return errorToResponse(error);

--- a/src/app/api/tutorial/route.ts
+++ b/src/app/api/tutorial/route.ts
@@ -1,7 +1,13 @@
 import { withAuth, type AuthedRequest } from "@/lib/auth";
-import { errorToResponse } from "@/lib/errors";
+import { withTransaction } from "@/lib/db";
+import {
+  errorToResponse,
+  NotFoundError,
+  ValidationError,
+} from "@/lib/errors";
 import { asQuestionId } from "@/lib/db-brands";
 import { insertTutorial, listTutorials } from "@/lib/queries/tutorials";
+import { getQuestionsByIds } from "@/lib/queries/questions";
 import { linkQuestionTutorial } from "@/lib/queries/questions-tutorials";
 import {
   createTutorialSchema,
@@ -43,24 +49,43 @@ export const POST = withAuth(async (req: AuthedRequest) => {
       validateVideoUrl(parsed.embedded_video_url);
     }
 
-    const tutorial = await insertTutorial({
-      user_id: req.userId,
-      question_id: null,
-      title: parsed.title,
-      content: parsed.content,
-      embedded_video_url: parsed.embedded_video_url ?? null,
+    const requestedIds = parsed.question_ids.map(asQuestionId);
+    const uniqueIds = Array.from(new Set(requestedIds));
+
+    const result = await withTransaction(async (client) => {
+      const found = await getQuestionsByIds(uniqueIds, client);
+      const foundById = new Map(found.map((q) => [q.question_id, q]));
+
+      for (const qid of uniqueIds) {
+        const question = foundById.get(qid);
+        if (!question) {
+          throw new NotFoundError(`Question not found: ${qid}`);
+        }
+        if (question.user_id === req.userId) {
+          throw new ValidationError(
+            "You cannot link a tutorial to your own question",
+          );
+        }
+      }
+
+      const tutorial = await insertTutorial(
+        {
+          user_id: req.userId,
+          title: parsed.title,
+          content: parsed.content,
+          embedded_video_url: parsed.embedded_video_url ?? null,
+        },
+        client,
+      );
+
+      for (const qid of uniqueIds) {
+        await linkQuestionTutorial(qid, tutorial.tutorial_id, client);
+      }
+
+      return { tutorial, linked_question_ids: uniqueIds };
     });
 
-    if (parsed.question_ids?.length) {
-      for (const qid of parsed.question_ids) {
-        await linkQuestionTutorial(asQuestionId(qid), tutorial.tutorial_id);
-      }
-    }
-
-    return NextResponse.json(
-      { tutorial, linked_question_ids: parsed.question_ids ?? [] },
-      { status: 201 },
-    );
+    return NextResponse.json(result, { status: 201 });
   } catch (error) {
     return errorToResponse(error);
   }

--- a/src/app/api/tutorial/route.ts
+++ b/src/app/api/tutorial/route.ts
@@ -1,0 +1,67 @@
+import { withAuth, type AuthedRequest } from "@/lib/auth";
+import { errorToResponse } from "@/lib/errors";
+import { asQuestionId } from "@/lib/db-brands";
+import { insertTutorial, listTutorials } from "@/lib/queries/tutorials";
+import { linkQuestionTutorial } from "@/lib/queries/questions-tutorials";
+import {
+  createTutorialSchema,
+  parseOrThrow,
+  validateVideoUrl,
+} from "@/lib/validation/tutorial";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(request: NextRequest) {
+  try {
+    const sp = request.nextUrl.searchParams;
+    const page = Math.max(parseInt(sp.get("page") || "1"), 1);
+    const limit = Math.min(
+      Math.max(parseInt(sp.get("limit") || "20"), 1),
+      100,
+    );
+    const category = sp.get("category") || undefined;
+    const offset = (page - 1) * limit;
+
+    const tutorials = await listTutorials(limit, offset, category);
+
+    return NextResponse.json({
+      tutorials,
+      page,
+      limit,
+      hasMore: tutorials.length === limit,
+    });
+  } catch (error) {
+    return errorToResponse(error);
+  }
+}
+
+export const POST = withAuth(async (req: AuthedRequest) => {
+  try {
+    const body = await req.json();
+    const parsed = parseOrThrow(createTutorialSchema, body);
+
+    if (parsed.embedded_video_url) {
+      validateVideoUrl(parsed.embedded_video_url);
+    }
+
+    const tutorial = await insertTutorial({
+      user_id: req.userId,
+      question_id: null,
+      title: parsed.title,
+      content: parsed.content,
+      embedded_video_url: parsed.embedded_video_url ?? null,
+    });
+
+    if (parsed.question_ids?.length) {
+      for (const qid of parsed.question_ids) {
+        await linkQuestionTutorial(asQuestionId(qid), tutorial.tutorial_id);
+      }
+    }
+
+    return NextResponse.json(
+      { tutorial, linked_question_ids: parsed.question_ids ?? [] },
+      { status: 201 },
+    );
+  } catch (error) {
+    return errorToResponse(error);
+  }
+});

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,7 +1,6 @@
 @import "tailwindcss";
 
 :root {
-  /* light mode */
   --primary-50: #eef2ff;
   --primary-100: #e0e7ff;
   --primary-200: #c7d2fe;

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -14,6 +14,10 @@ export default function ProfilePage() {
   const router = useRouter();
 
   useEffect(() => {
+    if (!localStorage.getItem("token")) {
+      router.push("/login");
+      return;
+    }
     const userStr = localStorage.getItem("user");
     if (userStr) {
       try {

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -25,7 +25,7 @@ export default function ProfilePage() {
         const inst = user.institution || "University";
         setSubtitle(`${eduFormatted} @ ${inst}`);
       } catch (e) {
-        console.error(e);
+        console.error("Failed to parse user from localStorage", e);
       }
     }
 

--- a/src/app/tutorials/create/page.tsx
+++ b/src/app/tutorials/create/page.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
+
+type QuestionPreview = {
+  question_id: string;
+  content: string;
+  category: string;
+  created_at: string;
+};
+
+export default function CreateTutorialPage() {
+  const searchParams = useSearchParams();
+  const questionId = searchParams.get("question");
+
+  const [preview, setPreview] = useState<QuestionPreview | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!questionId) return;
+    const ctrl = new AbortController();
+    setLoading(true);
+    setError(null);
+
+    fetch(
+      `/api/tutorial/question-preview?questionId=${encodeURIComponent(questionId)}`,
+      { signal: ctrl.signal },
+    )
+      .then(async (res) => {
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          throw new Error(body.error || `Preview failed (${res.status})`);
+        }
+        return res.json();
+      })
+      .then((data: QuestionPreview) => setPreview(data))
+      .catch((err: unknown) => {
+        if (err instanceof Error && err.name !== "AbortError") {
+          setError(err.message);
+        }
+      })
+      .finally(() => setLoading(false));
+
+    return () => ctrl.abort();
+  }, [questionId]);
+
+  return (
+    <div className="p-6 max-w-3xl mx-auto">
+      <h1 className="text-2xl font-semibold mb-4">Create Tutorial</h1>
+
+      {questionId ? (
+        <section className="mb-6 p-4 border border-border rounded-lg bg-muted/30">
+          <h2 className="text-sm font-medium text-muted-foreground mb-2">
+            Responding to question
+          </h2>
+          {loading && <p className="text-sm">Loading preview…</p>}
+          {error && (
+            <p className="text-sm text-red-500">Could not load: {error}</p>
+          )}
+          {preview && (
+            <div>
+              <p className="text-xs uppercase tracking-wide text-muted-foreground mb-1">
+                {preview.category}
+              </p>
+              <p className="text-base">{preview.content}</p>
+            </div>
+          )}
+        </section>
+      ) : (
+        <p className="text-sm text-muted-foreground mb-6">
+          No source question selected. The tutorial will be created standalone.
+        </p>
+      )}
+
+      <p className="text-sm text-muted-foreground">
+        Tutorial editor form goes here. On submit, POST /api/tutorial with the
+        title, content, optional embedded_video_url, and{" "}
+        <code>question_ids</code> seeded from the URL parameter.
+      </p>
+    </div>
+  );
+}

--- a/src/app/tutorials/create/page.tsx
+++ b/src/app/tutorials/create/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useSearchParams } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useState, Suspense } from "react";
 
 type QuestionPreview = {
   question_id: string;
@@ -10,7 +10,7 @@ type QuestionPreview = {
   created_at: string;
 };
 
-export default function CreateTutorialPage() {
+function CreateTutorialForm() {
   const searchParams = useSearchParams();
   const questionId = searchParams.get("question");
 
@@ -69,16 +69,27 @@ export default function CreateTutorialPage() {
           )}
         </section>
       ) : (
-        <p className="text-sm text-muted-foreground mb-6">
-          No source question selected. The tutorial will be created standalone.
+        <p className="text-sm text-red-500 mb-6">
+          A source question is required. Open this page from a question to
+          start a tutorial in response to it.
         </p>
       )}
 
-      <p className="text-sm text-muted-foreground">
-        Tutorial editor form goes here. On submit, POST /api/tutorial with the
-        title, content, optional embedded_video_url, and{" "}
-        <code>question_ids</code> seeded from the URL parameter.
-      </p>
+      {questionId && (
+        <p className="text-sm text-muted-foreground">
+          Tutorial editor form goes here. On submit, POST /api/tutorial with
+          the title, content, optional embedded_video_url, and{" "}
+          <code>question_ids: [&quot;{questionId}&quot;]</code>.
+        </p>
+      )}
     </div>
+  );
+}
+
+export default function CreateTutorialPage() {
+  return (
+    <Suspense>
+      <CreateTutorialForm />
+    </Suspense>
   );
 }

--- a/src/app/tutorials/create/page.tsx
+++ b/src/app/tutorials/create/page.tsx
@@ -21,6 +21,7 @@ function CreateTutorialForm() {
   useEffect(() => {
     if (!questionId) return;
     const ctrl = new AbortController();
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setLoading(true);
     setError(null);
 

--- a/src/components/navigation/topnavbar.tsx
+++ b/src/components/navigation/topnavbar.tsx
@@ -41,6 +41,9 @@ export default function TopNavBar({}: TopNavBarProps) {
     hoverColor: "primary-500",
   };
 
+  const isActive = (prefix: string) =>
+    pathname === prefix || pathname.startsWith(prefix + "/");
+
   return (
     <div
       id="topnavbar-container"
@@ -61,24 +64,24 @@ export default function TopNavBar({}: TopNavBarProps) {
         className="flex flex-row gap-3 absolute left-1/2 -translate-x-1/2"
       >
         <Link href="/home">
-          <TextButton 
-            label="Home" 
-            {...defaultTextButtonConfig} 
-            isSelected={pathname === "/home"} 
+          <TextButton
+            label="Home"
+            {...defaultTextButtonConfig}
+            isSelected={isActive("/home")}
           />
         </Link>
         <Link href="/tutorials">
-          <TextButton 
-            label="Tutorials" 
-            {...defaultTextButtonConfig} 
-            isSelected={pathname === "/tutorials"} 
+          <TextButton
+            label="Tutorials"
+            {...defaultTextButtonConfig}
+            isSelected={isActive("/tutorials")}
           />
         </Link>
         <Link href="/questions">
-          <TextButton 
-            label="Questions" 
-            {...defaultTextButtonConfig} 
-            isSelected={pathname === "/questions"} 
+          <TextButton
+            label="Questions"
+            {...defaultTextButtonConfig}
+            isSelected={isActive("/questions")}
           />
         </Link>
       </div>

--- a/src/components/navigation/topnavbar.tsx
+++ b/src/components/navigation/topnavbar.tsx
@@ -5,6 +5,10 @@ import TextButton from "../inputs/textbutton";
 import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
 
+function formatEducationLevel(level: string): string {
+  return level.charAt(0).toUpperCase() + level.slice(1).replace("_", " ");
+}
+
 interface TopNavBarProps {}
 
 export default function TopNavBar({}: TopNavBarProps) {
@@ -20,8 +24,7 @@ export default function TopNavBar({}: TopNavBarProps) {
         if (user) {
           setUserName(user.user_name || "User");
           const edu = user.education_level || "Undergraduate";
-          // Capitalize first letter and replace underscores
-          setEducation(edu.charAt(0).toUpperCase() + edu.slice(1).replace("_", " "));
+          setEducation(formatEducationLevel(edu));
         }
       } catch (e) {
         console.error("Failed to parse user from localStorage", e);

--- a/src/components/navigation/topnavbar.tsx
+++ b/src/components/navigation/topnavbar.tsx
@@ -20,7 +20,7 @@ export default function TopNavBar({}: TopNavBarProps) {
     const userStr = localStorage.getItem("user");
     if (userStr) {
       try {
-        const user = JSON.stringify(userStr) ? JSON.parse(userStr) : null;
+        const user = JSON.parse(userStr);
         if (user) {
           setUserName(user.user_name || "User");
           const edu = user.education_level || "Undergraduate";

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -5,7 +5,7 @@ import { NextRequest, NextResponse } from "next/server";
 import type { User, UserID } from "@/types/database";
 import { AuthError, errorToResponse } from "@/lib/errors";
 
-const JWT_SECRET =
+export const JWT_SECRET =
   process.env.JWT_SECRET || "your-secret-key-change-in-production";
 const SALT_ROUNDS = 10;
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -3,6 +3,7 @@ import bcrypt from "bcrypt";
 import jwt from "jsonwebtoken";
 import { NextRequest, NextResponse } from "next/server";
 import type { User, UserID } from "@/types/database";
+import { AuthError, errorToResponse } from "@/lib/errors";
 
 const JWT_SECRET =
   process.env.JWT_SECRET || "your-secret-key-change-in-production";
@@ -31,7 +32,7 @@ export function withAuth(handler: RouteHandler) {
     const authHeader = req.headers.get("authorization");
 
     if (!authHeader?.startsWith("Bearer ")) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+      return errorToResponse(new AuthError("Unauthorized"));
     }
 
     const token = authHeader.slice(7);
@@ -41,7 +42,7 @@ export function withAuth(handler: RouteHandler) {
       (req as AuthedRequest).userId = payload.userId as UserID;
       return handler(req as AuthedRequest);
     } catch {
-      return NextResponse.json({ error: "Invalid token" }, { status: 401 });
+      return errorToResponse(new AuthError("Invalid token"));
     }
   };
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -2,7 +2,7 @@ import "server-only";
 import bcrypt from "bcrypt";
 import jwt from "jsonwebtoken";
 import { NextRequest, NextResponse } from "next/server";
-import type { User, UserID } from "@/types/database";
+import type { UserID } from "@/types/database";
 import { AuthError, errorToResponse } from "@/lib/errors";
 
 export const JWT_SECRET =

--- a/src/lib/db-brands.ts
+++ b/src/lib/db-brands.ts
@@ -6,6 +6,7 @@ import type {
   InteractionID,
   QuestionID,
   TutorialID,
+  TutorialMaterialID,
   UserID,
 } from "@/types/database";
 import "server-only";
@@ -16,6 +17,7 @@ export const asTutorialId = (s: string) => s as TutorialID;
 export const asAnswerId = (n: number) => n as AnswerID;
 export const asCommentId = (n: number) => n as CommentID;
 export const asInteractionId = (n: number) => n as InteractionID;
+export const asTutorialMaterialId = (s: string) => s as TutorialMaterialID;
 
 export type InteractionRow = {
   interaction_id: number;

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { Pool, type QueryResultRow } from "pg";
+import { Pool, type PoolClient, type QueryResultRow } from "pg";
 
 declare global {
   var __pgPool: Pool | undefined;
@@ -32,4 +32,43 @@ export async function one<T extends QueryResultRow>(
 ): Promise<T | null> {
   const rows = await q<T>(sql, params);
   return rows[0] ?? null;
+}
+
+export async function qOn<T extends QueryResultRow>(
+  client: PoolClient,
+  sql: string,
+  params: readonly unknown[] = [],
+): Promise<T[]> {
+  const res = await client.query<T>(sql, params as unknown[]);
+  return res.rows;
+}
+
+export async function oneOn<T extends QueryResultRow>(
+  client: PoolClient,
+  sql: string,
+  params: readonly unknown[] = [],
+): Promise<T | null> {
+  const rows = await qOn<T>(client, sql, params);
+  return rows[0] ?? null;
+}
+
+export async function withTransaction<T>(
+  fn: (client: PoolClient) => Promise<T>,
+): Promise<T> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const result = await fn(client);
+    await client.query("COMMIT");
+    return result;
+  } catch (err) {
+    try {
+      await client.query("ROLLBACK");
+    } catch {
+      // ignore rollback errors; surface the original
+    }
+    throw err;
+  } finally {
+    client.release();
+  }
 }

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -30,6 +30,12 @@ export class NotFoundError extends AppError {
   }
 }
 
+export class ForbiddenError extends AppError {
+  constructor(message = "Forbidden") {
+    super(message, 403, "FORBIDDEN");
+  }
+}
+
 export class ConflictError extends AppError {
   constructor(message: string) {
     super(message, 409, "CONFLICT");

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -36,6 +36,12 @@ export class ConflictError extends AppError {
   }
 }
 
+export class RateLimitError extends AppError {
+  constructor(message = "Too many requests") {
+    super(message, 429, "RATE_LIMIT_EXCEEDED");
+  }
+}
+
 export class DatabaseError extends AppError {
   constructor(message = "Database operation failed") {
     super(message, 500, "DATABASE_ERROR");
@@ -50,7 +56,6 @@ export function errorToResponse(error: unknown): NextResponse {
     );
   }
 
-  const message = error instanceof Error ? error.message : "Unknown error";
   console.error("[Unhandled Error]", error);
   return NextResponse.json(
     { error: "Internal Server Error", code: "INTERNAL_ERROR" },

--- a/src/lib/navigation/tutorial.ts
+++ b/src/lib/navigation/tutorial.ts
@@ -1,0 +1,14 @@
+import type { AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime";
+
+export function navigateToTutorialCreation(
+  questionId: string,
+  router: AppRouterInstance,
+): void {
+  const qs = new URLSearchParams({ question: questionId });
+  router.push(`/tutorials/create?${qs.toString()}`);
+}
+
+export function tutorialCreationHref(questionId: string): string {
+  const qs = new URLSearchParams({ question: questionId });
+  return `/tutorials/create?${qs.toString()}`;
+}

--- a/src/lib/queries/questions-tutorials.ts
+++ b/src/lib/queries/questions-tutorials.ts
@@ -49,3 +49,13 @@ export async function tutorialsForQuestion(
   );
   return rows.map(mapQT);
 }
+
+export async function questionsForTutorial(
+  tid: TutorialID,
+): Promise<QuestionsTutorials[]> {
+  const rows = await q<QTRow>(
+    "SELECT * FROM questions_tutorials WHERE tutorial_id = $1",
+    [tid],
+  );
+  return rows.map(mapQT);
+}

--- a/src/lib/queries/questions-tutorials.ts
+++ b/src/lib/queries/questions-tutorials.ts
@@ -1,10 +1,11 @@
-import { q } from "@/lib/db";
+import { q, qOn } from "@/lib/db";
 import { asQuestionId, asTutorialId } from "@/lib/db-brands";
 import type {
   QuestionID,
   QuestionsTutorials,
   TutorialID,
 } from "@/types/database";
+import type { PoolClient } from "pg";
 import "server-only";
 
 type QTRow = { question_id: string; tutorial_id: string };
@@ -19,13 +20,20 @@ function mapQT(r: QTRow): QuestionsTutorials {
 export async function linkQuestionTutorial(
   qid: QuestionID,
   tid: TutorialID,
-): Promise<QuestionsTutorials[]> {
-  const rows = await q<QTRow>(
-    `INSERT INTO questions_tutorials (question_id, tutorial_id)
-     VALUES ($1, $2) ON CONFLICT DO NOTHING RETURNING *`,
-    [qid, tid],
-  );
-  return rows.map(mapQT);
+  client?: PoolClient,
+): Promise<{ link: QuestionsTutorials; created: boolean }> {
+  const insertSql = `INSERT INTO questions_tutorials (question_id, tutorial_id)
+     VALUES ($1, $2) ON CONFLICT DO NOTHING RETURNING *`;
+  const inserted = client
+    ? await qOn<QTRow>(client, insertSql, [qid, tid])
+    : await q<QTRow>(insertSql, [qid, tid]);
+  if (inserted.length > 0) {
+    return { link: mapQT(inserted[0]), created: true };
+  }
+  return {
+    link: mapQT({ question_id: qid, tutorial_id: tid }),
+    created: false,
+  };
 }
 
 export async function unlinkQuestionTutorial(

--- a/src/lib/queries/questions.ts
+++ b/src/lib/queries/questions.ts
@@ -1,7 +1,8 @@
-import { one, q } from "@/lib/db";
+import { one, q, qOn } from "@/lib/db";
 import { asQuestionId, asUserId } from "@/lib/db-brands";
 import { DatabaseError } from "@/lib/errors";
 import type { QuestionID, Questions, UserID } from "@/types/database";
+import type { PoolClient } from "pg";
 import "server-only";
 
 type QuestionRow = Omit<Questions, "question_id" | "user_id"> & {
@@ -52,6 +53,22 @@ export async function insertQuestion(
   );
   if (!row) throw new DatabaseError("insertQuestion: no row returned");
   return mapQuestion(row);
+}
+
+export async function getQuestionsByIds(
+  ids: QuestionID[],
+  client?: PoolClient,
+): Promise<Pick<Questions, "question_id" | "user_id">[]> {
+  if (ids.length === 0) return [];
+  const sql =
+    "SELECT question_id, user_id FROM questions WHERE question_id = ANY($1::uuid[])";
+  const rows = client
+    ? await qOn<{ question_id: string; user_id: string }>(client, sql, [ids])
+    : await q<{ question_id: string; user_id: string }>(sql, [ids]);
+  return rows.map((r) => ({
+    question_id: asQuestionId(r.question_id),
+    user_id: asUserId(r.user_id),
+  }));
 }
 
 export async function markResolved(id: QuestionID): Promise<Questions | null> {

--- a/src/lib/queries/tutorial-materials.ts
+++ b/src/lib/queries/tutorial-materials.ts
@@ -1,0 +1,86 @@
+import { one, q } from "@/lib/db";
+import { asTutorialId, asTutorialMaterialId } from "@/lib/db-brands";
+import { DatabaseError } from "@/lib/errors";
+import type {
+  TutorialID,
+  TutorialMaterial,
+  TutorialMaterialID,
+} from "@/types/database";
+import "server-only";
+
+type TutorialMaterialRow = Omit<
+  TutorialMaterial,
+  "material_id" | "tutorial_id" | "size_bytes"
+> & {
+  material_id: string;
+  tutorial_id: string;
+  size_bytes: string | number;
+};
+
+function mapMaterial(r: TutorialMaterialRow): TutorialMaterial {
+  return {
+    ...r,
+    material_id: asTutorialMaterialId(r.material_id),
+    tutorial_id: asTutorialId(r.tutorial_id),
+    size_bytes:
+      typeof r.size_bytes === "string"
+        ? Number(r.size_bytes)
+        : r.size_bytes,
+  };
+}
+
+export async function insertTutorialMaterial(input: {
+  tutorial_id: TutorialID;
+  file_name: string;
+  storage_key: string;
+  mime_type: string;
+  size_bytes: number;
+}): Promise<TutorialMaterial> {
+  const row = await one<TutorialMaterialRow>(
+    `INSERT INTO tutorial_materials
+       (material_id, tutorial_id, file_name, storage_key, mime_type, size_bytes)
+     VALUES (gen_random_uuid(), $1, $2, $3, $4, $5)
+     RETURNING *`,
+    [
+      input.tutorial_id,
+      input.file_name,
+      input.storage_key,
+      input.mime_type,
+      input.size_bytes,
+    ],
+  );
+  if (!row) throw new DatabaseError("insertTutorialMaterial: no row returned");
+  return mapMaterial(row);
+}
+
+export async function listMaterialsForTutorial(
+  tid: TutorialID,
+): Promise<TutorialMaterial[]> {
+  const rows = await q<TutorialMaterialRow>(
+    `SELECT * FROM tutorial_materials
+     WHERE tutorial_id = $1
+     ORDER BY uploaded_at DESC`,
+    [tid],
+  );
+  return rows.map(mapMaterial);
+}
+
+export async function getMaterialById(
+  id: TutorialMaterialID,
+): Promise<TutorialMaterial | null> {
+  const row = await one<TutorialMaterialRow>(
+    "SELECT * FROM tutorial_materials WHERE material_id = $1",
+    [id],
+  );
+  return row ? mapMaterial(row) : null;
+}
+
+export async function deleteMaterial(
+  id: TutorialMaterialID,
+): Promise<TutorialMaterial | null> {
+  const row = await one<TutorialMaterialRow>(
+    "DELETE FROM tutorial_materials WHERE material_id = $1 RETURNING *",
+    [id],
+  );
+  return row ? mapMaterial(row) : null;
+}

--- a/src/lib/queries/tutorials.ts
+++ b/src/lib/queries/tutorials.ts
@@ -31,7 +31,7 @@ export async function getTutorialById(
   id: TutorialID,
 ): Promise<Tutorials | null> {
   const row = await one<TutorialRow>(
-    "SELECT * FROM tutorials WHERE tutorial_id = $1",
+    "SELECT * FROM tutorials WHERE tutorial_id = $1 AND deleted_at IS NULL",
     [id],
   );
   return row ? mapTutorial(row) : null;
@@ -40,10 +40,29 @@ export async function getTutorialById(
 export async function listTutorials(
   limit: number,
   offset: number,
+  category?: string,
 ): Promise<Tutorials[]> {
+  const safeLimit = Math.min(Math.max(limit, 1), 100);
+  const safeOffset = Math.max(offset, 0);
+
+  if (category) {
+    const rows = await q<TutorialRow>(
+      `SELECT DISTINCT t.* FROM tutorials t
+       LEFT JOIN questions_tutorials qt ON qt.tutorial_id = t.tutorial_id
+       LEFT JOIN questions q ON q.question_id = qt.question_id
+       WHERE t.deleted_at IS NULL AND q.category = $3
+       ORDER BY t.created_at DESC
+       LIMIT $1 OFFSET $2`,
+      [safeLimit, safeOffset, category],
+    );
+    return rows.map(mapTutorial);
+  }
+
   const rows = await q<TutorialRow>(
-    "SELECT * FROM tutorials ORDER BY created_at DESC LIMIT $1 OFFSET $2",
-    [Math.min(Math.max(limit, 1), 100), Math.max(offset, 0)],
+    `SELECT * FROM tutorials
+     WHERE deleted_at IS NULL
+     ORDER BY created_at DESC LIMIT $1 OFFSET $2`,
+    [safeLimit, safeOffset],
   );
   return rows.map(mapTutorial);
 }

--- a/src/lib/queries/tutorials.ts
+++ b/src/lib/queries/tutorials.ts
@@ -90,3 +90,66 @@ export async function insertTutorial(input: {
   if (!row) throw new DatabaseError("insertTutorial: no row returned");
   return mapTutorial(row);
 }
+
+export async function updateTutorial(
+  id: TutorialID,
+  input: {
+    title?: string;
+    content?: string;
+    embedded_video_url?: string | null;
+  },
+): Promise<Tutorials | null> {
+  const sets: string[] = [];
+  const params: unknown[] = [];
+
+  if (input.title !== undefined) {
+    params.push(input.title);
+    sets.push(`title = $${params.length}`);
+  }
+  if (input.content !== undefined) {
+    params.push(input.content);
+    sets.push(`content = $${params.length}`);
+  }
+  if (input.embedded_video_url !== undefined) {
+    params.push(input.embedded_video_url);
+    sets.push(`embedded_video_url = $${params.length}`);
+  }
+
+  if (sets.length === 0) {
+    return getTutorialById(id);
+  }
+
+  params.push(id);
+  const row = await one<TutorialRow>(
+    `UPDATE tutorials SET ${sets.join(", ")}
+     WHERE tutorial_id = $${params.length} AND deleted_at IS NULL
+     RETURNING *`,
+    params,
+  );
+  return row ? mapTutorial(row) : null;
+}
+
+export async function softDeleteTutorial(
+  id: TutorialID,
+): Promise<Tutorials | null> {
+  const row = await one<TutorialRow>(
+    `UPDATE tutorials SET deleted_at = now()
+     WHERE tutorial_id = $1 AND deleted_at IS NULL
+     RETURNING *`,
+    [id],
+  );
+  return row ? mapTutorial(row) : null;
+}
+
+export async function hardDeleteExpiredTutorials(
+  olderThanDays: number,
+): Promise<number> {
+  const rows = await q<{ tutorial_id: string }>(
+    `DELETE FROM tutorials
+     WHERE deleted_at IS NOT NULL
+       AND deleted_at < now() - ($1 || ' days')::interval
+     RETURNING tutorial_id`,
+    [olderThanDays],
+  );
+  return rows.length;
+}

--- a/src/lib/queries/tutorials.ts
+++ b/src/lib/queries/tutorials.ts
@@ -1,21 +1,13 @@
-import { one, q } from "@/lib/db";
-import { asQuestionId, asTutorialId, asUserId } from "@/lib/db-brands";
+import { one, oneOn, q } from "@/lib/db";
+import { asTutorialId, asUserId } from "@/lib/db-brands";
 import { DatabaseError } from "@/lib/errors";
-import type {
-  QuestionID,
-  TutorialID,
-  Tutorials,
-  UserID,
-} from "@/types/database";
+import type { TutorialID, Tutorials, UserID } from "@/types/database";
+import type { PoolClient } from "pg";
 import "server-only";
 
-type TutorialRow = Omit<
-  Tutorials,
-  "tutorial_id" | "user_id" | "question_id"
-> & {
+type TutorialRow = Omit<Tutorials, "tutorial_id" | "user_id"> & {
   tutorial_id: string;
   user_id: string;
-  question_id: string | null;
 };
 
 function mapTutorial(r: TutorialRow): Tutorials {
@@ -23,7 +15,6 @@ function mapTutorial(r: TutorialRow): Tutorials {
     ...r,
     tutorial_id: asTutorialId(r.tutorial_id),
     user_id: asUserId(r.user_id),
-    question_id: r.question_id !== null ? asQuestionId(r.question_id) : null,
   };
 }
 
@@ -67,26 +58,28 @@ export async function listTutorials(
   return rows.map(mapTutorial);
 }
 
-export async function insertTutorial(input: {
-  user_id: UserID;
-  question_id: QuestionID | null;
-  title: string;
-  content: string;
-  embedded_video_url: string | null;
-}): Promise<Tutorials> {
-  const row = await one<TutorialRow>(
-    `INSERT INTO tutorials
-       (tutorial_id, user_id, question_id, title, content, embedded_video_url)
-     VALUES (gen_random_uuid(), $1, $2, $3, $4, $5)
-     RETURNING *`,
-    [
-      input.user_id,
-      input.question_id,
-      input.title,
-      input.content,
-      input.embedded_video_url,
-    ],
-  );
+export async function insertTutorial(
+  input: {
+    user_id: UserID;
+    title: string;
+    content: string;
+    embedded_video_url: string | null;
+  },
+  client?: PoolClient,
+): Promise<Tutorials> {
+  const sql = `INSERT INTO tutorials
+       (tutorial_id, user_id, title, content, embedded_video_url)
+     VALUES (gen_random_uuid(), $1, $2, $3, $4)
+     RETURNING *`;
+  const params = [
+    input.user_id,
+    input.title,
+    input.content,
+    input.embedded_video_url,
+  ];
+  const row = client
+    ? await oneOn<TutorialRow>(client, sql, params)
+    : await one<TutorialRow>(sql, params);
   if (!row) throw new DatabaseError("insertTutorial: no row returned");
   return mapTutorial(row);
 }

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -1,0 +1,27 @@
+import "server-only";
+import { localStorage } from "@/lib/storage/local";
+import { s3Storage } from "@/lib/storage/s3";
+import { supabaseStorage } from "@/lib/storage/supabase";
+
+export interface StorageDriver {
+  put(opts: {
+    key: string;
+    buffer: Buffer;
+    mimeType: string;
+  }): Promise<string>;
+  getUrl(key: string): string;
+  delete(key: string): Promise<void>;
+}
+
+export function getStorage(): StorageDriver {
+  const backend = (process.env.STORAGE_BACKEND || "local").toLowerCase();
+  switch (backend) {
+    case "s3":
+      return s3Storage;
+    case "supabase":
+      return supabaseStorage;
+    case "local":
+    default:
+      return localStorage;
+  }
+}

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -3,13 +3,15 @@ import { localStorage } from "@/lib/storage/local";
 import { s3Storage } from "@/lib/storage/s3";
 import { supabaseStorage } from "@/lib/storage/supabase";
 
+export const DEFAULT_URL_TTL_SECONDS = 3600;
+
 export interface StorageDriver {
   put(opts: {
     key: string;
     buffer: Buffer;
     mimeType: string;
   }): Promise<string>;
-  getUrl(key: string): string;
+  getUrl(key: string, opts?: { expiresIn?: number }): Promise<string>;
   delete(key: string): Promise<void>;
 }
 

--- a/src/lib/storage/local.ts
+++ b/src/lib/storage/local.ts
@@ -1,9 +1,31 @@
 import "server-only";
 import { promises as fs } from "fs";
 import path from "path";
-import type { StorageDriver } from "@/lib/storage";
+import jwt from "jsonwebtoken";
+import { JWT_SECRET } from "@/lib/auth";
+import { AuthError } from "@/lib/errors";
+import {
+  DEFAULT_URL_TTL_SECONDS,
+  type StorageDriver,
+} from "@/lib/storage";
 
 const UPLOADS_ROOT = path.join(process.cwd(), "uploads");
+
+export function signFileToken(key: string, expiresIn: number): string {
+  return jwt.sign({ k: key }, JWT_SECRET, { expiresIn });
+}
+
+export function verifyFileToken(key: string, token: string): void {
+  try {
+    const payload = jwt.verify(token, JWT_SECRET) as { k?: string };
+    if (payload.k !== key) {
+      throw new AuthError("Invalid or expired file URL");
+    }
+  } catch (err) {
+    if (err instanceof AuthError) throw err;
+    throw new AuthError("Invalid or expired file URL");
+  }
+}
 
 function resolveSafe(key: string): string {
   const target = path.resolve(UPLOADS_ROOT, key);
@@ -22,8 +44,11 @@ export const localStorage: StorageDriver = {
     return key;
   },
 
-  async getUrl(key) {
-    return `/api/files/${key.split("/").map(encodeURIComponent).join("/")}`;
+  async getUrl(key, opts) {
+    const expiresIn = opts?.expiresIn ?? DEFAULT_URL_TTL_SECONDS;
+    const token = signFileToken(key, expiresIn);
+    const encodedPath = key.split("/").map(encodeURIComponent).join("/");
+    return `/api/files/${encodedPath}?token=${encodeURIComponent(token)}`;
   },
 
   async delete(key) {

--- a/src/lib/storage/local.ts
+++ b/src/lib/storage/local.ts
@@ -22,7 +22,7 @@ export const localStorage: StorageDriver = {
     return key;
   },
 
-  getUrl(key) {
+  async getUrl(key) {
     return `/api/files/${key.split("/").map(encodeURIComponent).join("/")}`;
   },
 

--- a/src/lib/storage/local.ts
+++ b/src/lib/storage/local.ts
@@ -1,0 +1,46 @@
+import "server-only";
+import { promises as fs } from "fs";
+import path from "path";
+import type { StorageDriver } from "@/lib/storage";
+
+const UPLOADS_ROOT = path.join(process.cwd(), "uploads");
+
+function resolveSafe(key: string): string {
+  const target = path.resolve(UPLOADS_ROOT, key);
+  const root = path.resolve(UPLOADS_ROOT);
+  if (target !== root && !target.startsWith(root + path.sep)) {
+    throw new Error("Invalid storage key (path traversal)");
+  }
+  return target;
+}
+
+export const localStorage: StorageDriver = {
+  async put({ key, buffer }) {
+    const target = resolveSafe(key);
+    await fs.mkdir(path.dirname(target), { recursive: true });
+    await fs.writeFile(target, buffer);
+    return key;
+  },
+
+  getUrl(key) {
+    return `/api/files/${key.split("/").map(encodeURIComponent).join("/")}`;
+  },
+
+  async delete(key) {
+    const target = resolveSafe(key);
+    await fs.rm(target, { force: true });
+  },
+};
+
+export async function readLocalFile(
+  key: string,
+): Promise<{ buffer: Buffer; size: number } | null> {
+  const target = resolveSafe(key);
+  try {
+    const buffer = await fs.readFile(target);
+    return { buffer, size: buffer.byteLength };
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw err;
+  }
+}

--- a/src/lib/storage/s3.ts
+++ b/src/lib/storage/s3.ts
@@ -1,0 +1,16 @@
+import "server-only";
+import type { StorageDriver } from "@/lib/storage";
+
+// Stub implementation. Fill in if AWS S3 / Cloudflare R2 is selected as
+// the production storage backend (see plan: open decision pending team leader).
+export const s3Storage: StorageDriver = {
+  async put() {
+    throw new Error("s3 storage not configured");
+  },
+  getUrl() {
+    throw new Error("s3 storage not configured");
+  },
+  async delete() {
+    throw new Error("s3 storage not configured");
+  },
+};

--- a/src/lib/storage/s3.ts
+++ b/src/lib/storage/s3.ts
@@ -1,11 +1,6 @@
 import "server-only";
 import type { StorageDriver } from "@/lib/storage";
 
-// Stub implementation. Fill in if AWS S3 / Cloudflare R2 is selected as
-// the production storage backend (see plan: open decision pending team leader).
-// When wiring getUrl, use:
-//   getSignedUrl(s3Client, new GetObjectCommand({ Bucket, Key: key }), { expiresIn })
-// from @aws-sdk/s3-request-presigner. expiresIn is seconds.
 export const s3Storage: StorageDriver = {
   async put() {
     throw new Error("s3 storage not configured");

--- a/src/lib/storage/s3.ts
+++ b/src/lib/storage/s3.ts
@@ -3,11 +3,14 @@ import type { StorageDriver } from "@/lib/storage";
 
 // Stub implementation. Fill in if AWS S3 / Cloudflare R2 is selected as
 // the production storage backend (see plan: open decision pending team leader).
+// When wiring getUrl, use:
+//   getSignedUrl(s3Client, new GetObjectCommand({ Bucket, Key: key }), { expiresIn })
+// from @aws-sdk/s3-request-presigner. expiresIn is seconds.
 export const s3Storage: StorageDriver = {
   async put() {
     throw new Error("s3 storage not configured");
   },
-  getUrl() {
+  async getUrl() {
     throw new Error("s3 storage not configured");
   },
   async delete() {

--- a/src/lib/storage/supabase.ts
+++ b/src/lib/storage/supabase.ts
@@ -1,11 +1,6 @@
 import "server-only";
 import type { StorageDriver } from "@/lib/storage";
 
-// Stub implementation. Fill in if Supabase Storage is selected as the
-// production backend (see plan: open decision pending team leader).
-// When wiring getUrl, use:
-//   supabase.storage.from(bucket).createSignedUrl(key, expiresIn)
-// expiresIn is seconds; the call returns { data: { signedUrl }, error }.
 export const supabaseStorage: StorageDriver = {
   async put() {
     throw new Error("supabase storage not configured");

--- a/src/lib/storage/supabase.ts
+++ b/src/lib/storage/supabase.ts
@@ -1,0 +1,16 @@
+import "server-only";
+import type { StorageDriver } from "@/lib/storage";
+
+// Stub implementation. Fill in if Supabase Storage is selected as the
+// production backend (see plan: open decision pending team leader).
+export const supabaseStorage: StorageDriver = {
+  async put() {
+    throw new Error("supabase storage not configured");
+  },
+  getUrl() {
+    throw new Error("supabase storage not configured");
+  },
+  async delete() {
+    throw new Error("supabase storage not configured");
+  },
+};

--- a/src/lib/storage/supabase.ts
+++ b/src/lib/storage/supabase.ts
@@ -3,11 +3,14 @@ import type { StorageDriver } from "@/lib/storage";
 
 // Stub implementation. Fill in if Supabase Storage is selected as the
 // production backend (see plan: open decision pending team leader).
+// When wiring getUrl, use:
+//   supabase.storage.from(bucket).createSignedUrl(key, expiresIn)
+// expiresIn is seconds; the call returns { data: { signedUrl }, error }.
 export const supabaseStorage: StorageDriver = {
   async put() {
     throw new Error("supabase storage not configured");
   },
-  getUrl() {
+  async getUrl() {
     throw new Error("supabase storage not configured");
   },
   async delete() {

--- a/src/lib/validation/tutorial.ts
+++ b/src/lib/validation/tutorial.ts
@@ -1,5 +1,15 @@
 import { ValidationError } from "@/lib/errors";
-import { z } from "zod";
+import { z, ZodType } from "zod";
+
+export function parseOrThrow<T>(schema: ZodType<T>, value: unknown): T {
+  const result = schema.safeParse(value);
+  if (!result.success) {
+    const first = result.error.issues[0];
+    const path = first.path.length ? `${first.path.join(".")}: ` : "";
+    throw new ValidationError(`${path}${first.message}`);
+  }
+  return result.data;
+}
 
 export const DOCUMENT_MIMES = [
   "application/pdf",
@@ -30,15 +40,15 @@ export const MAX_VIDEO_BYTES = 500 * 1024 * 1024;
 export const createTutorialSchema = z.object({
   title: z.string().min(1).max(255),
   content: z.string().min(1),
-  embedded_video_url: z.string().url().nullable().optional(),
-  question_ids: z.array(z.string().uuid()).optional(),
+  embedded_video_url: z.url().nullable().optional(),
+  question_ids: z.array(z.uuid()).optional(),
 });
 
 export const updateTutorialSchema = z
   .object({
     title: z.string().min(1).max(255).optional(),
     content: z.string().min(1).optional(),
-    embedded_video_url: z.string().url().nullable().optional(),
+    embedded_video_url: z.url().nullable().optional(),
   })
   .strict();
 

--- a/src/lib/validation/tutorial.ts
+++ b/src/lib/validation/tutorial.ts
@@ -1,0 +1,86 @@
+import { ValidationError } from "@/lib/errors";
+import { z } from "zod";
+
+export const DOCUMENT_MIMES = [
+  "application/pdf",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+] as const;
+
+export const VIDEO_MIMES = ["video/mp4", "video/webm", "video/ogg"] as const;
+
+export const ALLOWED_VIDEO_HOSTS = [
+  "youtube.com",
+  "www.youtube.com",
+  "youtu.be",
+  "vimeo.com",
+  "www.vimeo.com",
+  "player.vimeo.com",
+  "loom.com",
+  "www.loom.com",
+] as const;
+
+export const MAX_MATERIAL_BYTES = 10 * 1024 * 1024;
+export const MAX_VIDEO_BYTES = 500 * 1024 * 1024;
+
+export const createTutorialSchema = z.object({
+  title: z.string().min(1).max(255),
+  content: z.string().min(1),
+  embedded_video_url: z.string().url().nullable().optional(),
+  question_ids: z.array(z.string().uuid()).optional(),
+});
+
+export const updateTutorialSchema = z
+  .object({
+    title: z.string().min(1).max(255).optional(),
+    content: z.string().min(1).optional(),
+    embedded_video_url: z.string().url().nullable().optional(),
+  })
+  .strict();
+
+export function validateVideoUrl(url: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new ValidationError("Invalid video URL");
+  }
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    throw new ValidationError("Video URL must use http(s)");
+  }
+  const host = parsed.hostname.toLowerCase();
+  const allowed = (ALLOWED_VIDEO_HOSTS as readonly string[]).some(
+    (h) => host === h || host.endsWith(`.${h}`),
+  );
+  if (!allowed) {
+    throw new ValidationError(
+      `Video host not allowed. Allowed: ${ALLOWED_VIDEO_HOSTS.join(", ")}`,
+    );
+  }
+}
+
+export function validateMaterialFile(mime: string, sizeBytes: number): void {
+  if (!(DOCUMENT_MIMES as readonly string[]).includes(mime)) {
+    throw new ValidationError(`Unsupported material MIME type: ${mime}`);
+  }
+  if (sizeBytes <= 0 || sizeBytes > MAX_MATERIAL_BYTES) {
+    throw new ValidationError(
+      `Material exceeds ${MAX_MATERIAL_BYTES} bytes or is empty`,
+    );
+  }
+}
+
+export function validateVideoFile(mime: string, sizeBytes: number): void {
+  if (!(VIDEO_MIMES as readonly string[]).includes(mime)) {
+    throw new ValidationError(`Unsupported video MIME type: ${mime}`);
+  }
+  if (sizeBytes <= 0 || sizeBytes > MAX_VIDEO_BYTES) {
+    throw new ValidationError(
+      `Video exceeds ${MAX_VIDEO_BYTES} bytes or is empty`,
+    );
+  }
+}

--- a/src/lib/validation/tutorial.ts
+++ b/src/lib/validation/tutorial.ts
@@ -41,7 +41,7 @@ export const createTutorialSchema = z.object({
   title: z.string().min(1).max(255),
   content: z.string().min(1),
   embedded_video_url: z.url().nullable().optional(),
-  question_ids: z.array(z.uuid()).optional(),
+  question_ids: z.array(z.uuid()).min(1),
 });
 
 export const updateTutorialSchema = z

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { RateLimitError, errorToResponse } from "@/lib/errors";
 
 const rateLimitMap = new Map<string, { count: number; resetAt: number }>();
 
@@ -20,7 +21,7 @@ export default function proxy(req: NextRequest) {
   }
 
   if (entry.count >= RATE_LIMIT) {
-    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+    return errorToResponse(new RateLimitError());
   }
 
   entry.count++;

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -101,7 +101,6 @@ export interface QuestionsTutorials {
 export interface Tutorials {
   tutorial_id: TutorialID;
   user_id: UserID;
-  question_id: QuestionID | null;
   title: string;
   content: string;
   embedded_video_url: string | null;

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -4,6 +4,9 @@ export type TutorialID = string & { readonly _brand: "TutorialID" };
 export type AnswerID = number & { readonly _brand: "AnswerID" };
 export type CommentID = number & { readonly _brand: "CommentID" };
 export type InteractionID = number & { readonly _brand: "InteractionID" };
+export type TutorialMaterialID = string & {
+  readonly _brand: "TutorialMaterialID";
+};
 
 export interface User {
   user_id: UserID;
@@ -105,4 +108,15 @@ export interface Tutorials {
   content: string;
   embedded_video_url: string | null;
   created_at: Date;
+  deleted_at: Date | null;
+}
+
+export interface TutorialMaterial {
+  material_id: TutorialMaterialID;
+  tutorial_id: TutorialID;
+  file_name: string;
+  storage_key: string;
+  mime_type: string;
+  size_bytes: number;
+  uploaded_at: Date;
 }

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -4,9 +4,7 @@ export type TutorialID = string & { readonly _brand: "TutorialID" };
 export type AnswerID = number & { readonly _brand: "AnswerID" };
 export type CommentID = number & { readonly _brand: "CommentID" };
 export type InteractionID = number & { readonly _brand: "InteractionID" };
-export type TutorialMaterialID = string & {
-  readonly _brand: "TutorialMaterialID";
-};
+export type TutorialMaterialID = string & { readonly _brand: "TutorialMaterialID";};
 
 export interface User {
   user_id: UserID;


### PR DESCRIPTION
## Summary

Establishes the full backend for "Tutorial Creation Linked to Questions" — tutorials authored in response to high-demand questions, with mandatory question linking, transactional integrity on create, file/video uploads, soft-delete lifecycle, a cron purge, and a frontend navigation utility that shunts question context into the creation form. Built on the existing typed-throw error pattern and branded-ID query layer; everything composes through the same `errorToResponse` boundary and `pg` `q`/`one` helpers already in use.

- **Schema migration** in `database_schema.sql` — `ALTER TABLE tutorials ADD COLUMN deleted_at TIMESTAMP WITH TIME ZONE` with a partial index `idx_tutorials_deleted_at … WHERE deleted_at IS NOT NULL` for cheap soft-delete lookups; `tutorial_stats` view filtered to `WHERE t.deleted_at IS NULL` so analytics don't leak removed rows. New `tutorial_materials` table (UUID PK, FK CASCADE from `tutorials`, `file_name`, opaque `storage_key`, `mime_type`, `size_bytes BIGINT`, `uploaded_at`) with `idx_tutorial_materials_tutorial_id`. Legacy `tutorials.question_id` FK column dropped — `questions_tutorials` is now the single source of truth; `tutorial_stats` view updated to derive question linkage exclusively through the junction table. `/uploads` added to `.gitignore`.
- **Type system extensions** in `src/types/database.ts` — `Tutorials` gains `deleted_at: Date | null` and **loses `question_id`**; new `TutorialMaterialID` brand and `TutorialMaterial` interface. `src/lib/db-brands.ts` exports `asTutorialMaterialId`. The brand-at-the-edge invariant is preserved — material IDs flow as `TutorialMaterialID`, not raw `string`.
- **Transactional query primitives** in `src/lib/db.ts` — new `withTransaction`, `qOn(client, …)`, and `oneOn(client, …)` helpers let route handlers compose multi-statement work (insert tutorial + link N questions) under a single `BEGIN`/`COMMIT`, with the same typed-throw semantics as the top-level `q`/`one`. A bad question ID now rolls the entire create back instead of leaving a partially-linked tutorial.
- **Query layer additions** under `src/lib/queries/`:
    - tutorials.ts — every existing read (`getTutorialById`, `listTutorials`) now guards with `AND deleted_at IS NULL`, and all SELECTs were updated to drop the removed `question_id` column. `listTutorials` accepts an optional `category` param that joins through `questions_tutorials → questions.category`. New `updateTutorial` builds a dynamic SET clause over only provided fields; `softDeleteTutorial` flips `deleted_at = now()`; `hardDeleteExpiredTutorials(N)` returns the count of rows whose `deleted_at < now() - N days` for cron reporting.
    - tutorial-materials.ts (new) — `insertTutorialMaterial`, `listMaterialsForTutorial`, `getMaterialById`, `deleteMaterial`. Normalizes `size_bytes` from node-postgres's BIGINT-as-string back to `number`.
    - questions-tutorials.ts — adds `questionsForTutorial(tid)` as the inverse of the existing `tutorialsForQuestion`. `linkQuestionTutorial` is now **idempotent**: duplicate links return `linked: true` (was `false`) so callers don't have to special-case the conflict path. All link/unlink helpers accept an optional client for transaction participation.
    - questions.ts — new `getQuestionsByIds(ids)` batch query (client-aware) used by the create flow to existence-check every linked question in one round trip and to fetch their authors for the self-pose guard.
- **Validation utility** in `src/lib/validation/tutorial.ts` — Zod 4 schemas (`createTutorialSchema` now requires `question_ids: z.array(z.uuid()).min(1)`, `updateTutorialSchema` with `.strict()`) using `z.url()` / `z.uuid()`; document MIME whitelist (PDF, docx, pptx, png/jpg/gif/webp) capped at 10 MB; video MIME whitelist (mp4/webm/ogg) capped at 500 MB; allowed external video host whitelist (YouTube, Vimeo, Loom, with subdomain match). `validateVideoUrl`, `validateMaterialFile`, `validateVideoFile` throw `ValidationError` so `errorToResponse` returns 400 cleanly. `parseOrThrow(schema, value)` helper converts Zod's first issue into a `ValidationError` with a `path: message` shape, so route handlers don't have to special-case `ZodError`.
- **Storage abstraction** in `src/lib/storage/` — `StorageDriver` interface (`put`, `getUrl`, `delete`); `getUrl` is **async + TTL-aware** so signed-URL backends (S3/Supabase) fit the same shape as the local driver. Concrete `localStorage` driver writes under `<cwd>/uploads/` with a `path.resolve` traversal guard, served via the new `/api/files/[...key]` route with extension-based MIME detection; `s3Storage` and `supabaseStorage` ship as stubs that throw "not configured" pending the team-leader decision. `getStorage()` selects via `STORAGE_BACKEND` env (`local` | `s3` | `supabase`, default `local`).
- **REST API surface** under `src/app/api/tutorial/`:
    - `GET /api/tutorial` (public) — paginated list with optional `?category`.
    - `POST /api/tutorial` (auth) — `withAuth`-gated, `parseOrThrow(createTutorialSchema)`, validates `embedded_video_url`. Now batch-validates every `question_ids[]` exists (404 on first missing), enforces that the tutorial author is not the author of any linked question (`AuthError("Forbidden")` to block self-pose-then-tag), and runs the insert + all links inside `withTransaction` so a partial failure rolls everything back. Returns `{ tutorial, linked_question_ids }`.
    - `GET /api/tutorial/:tutorialId` (public) — returns the tutorial plus `linked_question_ids` from the junction table.
    - `PUT /api/tutorial/:tutorialId` (auth) — ownership check (`tutorial.user_id !== req.userId` → `AuthError("Forbidden")`), partial update via `updateTutorialSchema`, revalidates `embedded_video_url`.
    - `DELETE /api/tutorial/:tutorialId` (auth) — ownership check, soft-delete only.
    - `PUT /api/tutorial/:tutorialId/upload` (auth) — multipart `formData()`, `File` instance check, MIME-discriminated routing into `validateVideoFile` vs `validateMaterialFile`, writes to storage at `tutorials/<tid>/<uuid>-<sanitized-name>`, persists a `tutorial_materials` row, returns the row plus `url` and URL `expires_at` from `storage.getUrl(key)`.
    - `GET /api/tutorial/:tutorialId/materials` (public) — list materials for a tutorial.
    - `POST /api/tutorial/:tutorialId/questions` and `DELETE` — auth + ownership + question existence check before `linkQuestionTutorial` / `unlinkQuestionTutorial`. The same self-author guard applied at create time is enforced here, so the post-hoc link path can't be used to bypass it.
    - `GET /api/tutorial/question-preview?questionId=<uuid>` (public) — returns only safe public fields (`question_id`, `content`, `category`, `created_at`) for the creation-form preview panel.
    - `POST /api/cron/purge-tutorials` — gated by `Authorization: Bearer <CRON_SECRET>`. Collects `storage_key`s from `tutorial_materials` for tutorials soft-deleted >30 days ago, calls `storage.delete(key)` for each (logging file-delete failures non-fatally), then calls `hardDeleteExpiredTutorials(30)` so the SQL DELETE cascades through `tutorial_materials`, `questions_tutorials`, `comments`, `interactions`. Returns `{ deleted, files_removed }`.
- **Frontend navigation utility** in `src/lib/navigation/tutorial.ts` — client-safe (no `"server-only"`), exports `navigateToTutorialCreation(questionId, router)` and `tutorialCreationHref(questionId)` that build `/tutorials/create?question=<id>`. `src/app/tutorials/create/page.tsx` reads `useSearchParams().get("question")`, fetches `/api/tutorial/question-preview?questionId=...` (with `AbortController` cleanup), and renders the source question above the (placeholder) editor form. When no `?question=` is present, the page now renders an explicit error rather than offering a standalone-tutorial path — matches the API-side requirement that tutorials must link to ≥1 question. `useSearchParams` is wrapped in a `Suspense` boundary to clear Next.js's prerender warning.

### What's intentionally deferred

- **Production storage backend selection** — `s3.ts` and `supabase.ts` ship as throw-on-call stubs. `StorageDriver` (with async TTL-aware `getUrl`) is the isolation seam; only the concrete driver file changes once Supabase Storage (full-suite) vs AWS S3/R2 is decided by team leader. Selection via `STORAGE_BACKEND` env. Local dev works today via the `local` driver and `/api/files/`.
- **Streamed uploads** — current upload route buffers the full file via `Buffer.from(await file.arrayBuffer())`. Acceptable for the local-dev custom Node server in `server.ts` and for the 500 MB cap, but a `busboy`-based streaming path is the eventual upgrade for memory-bound deployments.
- **CRON_SECRET wiring + scheduler** — the route is in place and gated; the actual cron scheduler (Vercel Cron, Supabase scheduled functions, or external) is a deployment concern, not committed here. The route refuses to run if `CRON_SECRET` is unset.
- **Material delete REST handler** — `deleteMaterial` query exists; its REST handler is not yet exposed since the upload + list flow is the immediate priority.
- **Tutorial editor UI** — `/tutorials/create` renders the question preview and a placeholder describing the POST contract; the actual form (title/content/video URL fields, file picker, submit) is for the frontend pass.

### Relation to prior work

Builds on the typed-error refactor (`refactor(errors): add RateLimitError and standardize all error responses through errorToResponse`) — every new route uses the same `try { … } catch (error) { return errorToResponse(error); }` boundary, every validation path throws `ValidationError`, every ownership/self-author failure throws `AuthError("Forbidden")`. Builds on the `feat(db): add tutorial query functions` and `feat(db): add questions_tutorials join queries` modules — soft-delete filtering layered on top of the existing `getTutorialById` / `listTutorials`, and `linkQuestionTutorial` / `unlinkQuestionTutorial` are reused (now idempotent + transaction-aware) by the new link/unlink REST handlers. Builds on the `withAuth` HOC from src/lib/auth.ts — every mutation route is wrapped, every handler reads `req.userId: UserID` (branded) for the ownership and self-author checks. The only destructive change to the prior data model is the removal of the legacy `tutorials.question_id` FK, which the new junction-table-only invariant (and updated `tutorial_stats` view) supersedes.