### PR TITLE
feat: establish socket.io background server with real-time events

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -20,6 +20,26 @@ app.prepare().then(() => {
 
     socket.on("join:question", (questionId: string) => {
       socket.join(`question:${questionId}`);
+      console.log(`socket ${socket.id} joined question:${questionId}`);
+    });
+
+    socket.on("leave:question", (questionId: string) => {
+      socket.leave(`question:${questionId}`);
+      console.log(`socket ${socket.id} left question:${questionId}`);
+    });
+
+    socket.on("join:tutorial", (tutorialId: string) => {
+      socket.join(`tutorial:${tutorialId}`);
+      console.log(`socket ${socket.id} joined tutorial:${tutorialId}`);
+    });
+
+    socket.on("leave:tutorial", (tutorialId: string) => {
+      socket.leave(`tutorial:${tutorialId}`);
+    });
+
+    socket.on("join:feed", () => {
+      socket.join("feed");
+      console.log(`socket ${socket.id} joined feed`);
     });
 
     socket.on("disconnect", () => {
@@ -31,3 +51,23 @@ app.prepare().then(() => {
     console.log("> Ready on http://localhost:3000");
   });
 });
+
+export function emitNewAnswer(questionId: string, answer: object) {
+  const io = (global as any).io as Server;
+  io.to(`question:${questionId}`).emit("new:answer", answer);
+}
+
+export function emitNewComment(questionId: string, comment: object) {
+  const io = (global as any).io as Server;
+  io.to(`question:${questionId}`).emit("new:comment", comment);
+}
+
+export function emitDemandUpdate(questionId: string, demandScore: number) {
+  const io = (global as any).io as Server;
+  io.to("feed").emit("update:demand", { questionId, demandScore });
+}
+
+export function emitTutorialLinked(questionId: string, tutorial: object) {
+  const io = (global as any).io as Server;
+  io.to(`question:${questionId}`).emit("linked:tutorial", tutorial);
+}


### PR DESCRIPTION
Changes
- Added room-based socket.io events for questions, tutorials, and home feed
- Added leave:question and leave:tutorial events for room cleanup
- Added join:feed event for live demand score updates on home feed
- Added emit helper functions: emitNewAnswer, emitNewComment, emitDemandUpdate, emitTutorialLinked

 Notes
- Emit helpers can be imported and called directly from API routes when data changes
- Real-time events align with project features: demand score system, Q&A, and tutorial linking
- CORS currently set to * — will be tightened in production