### PR TITLE
fix: add missing getTutorialById import in tutorial route

### DIFF
--- a/src/app/api/tutorial/[tutorialId]/route.ts
+++ b/src/app/api/tutorial/[tutorialId]/route.ts
@@ -2,6 +2,7 @@ import { withAuth, type AuthedRequest } from "@/lib/auth";
 import { asTutorialId } from "@/lib/db-brands";
 import { errorToResponse, ForbiddenError, NotFoundError } from "@/lib/errors";
 import {
+  getTutorialById,
   getTutorialDetailedById,
   softDeleteTutorial,
   updateTutorial,


### PR DESCRIPTION
Changes
- Fixed missing get TutorialById import in src/app/api/tutorial/[tutorialId]/route.ts


notess
* All API routes already use centralized error handling with errorToResponse
* Error handling is consistent across the codebase
* This PR fixes a bug where PUT and DELETE methods called getTutorialById without importing it