### PR TITLE
feat: add Load More pagination to tutorials and questions pages

### DIFF
--- a/src/app/questions/page.tsx
+++ b/src/app/questions/page.tsx
@@ -7,23 +7,39 @@ import AskQuestionCard from "@/components/inputs/CreateCards/CreateQuestion";
 export default function QuestionsPage() {
   const [questions, setQuestions] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [page, setPage] = useState(1);
+  const [hasMore, setHasMore] = useState(true);
+
+  async function fetchQuestions(pageNum: number, append = false) {
+    try {
+      if (!append) setLoading(true);
+      else setLoadingMore(true);
+
+      const res = await fetch(`/api/questions?page=${pageNum}`);
+      const json = await res.json();
+
+      if (json.data) {
+        setQuestions((prev) => (append ? [...prev, ...json.data] : json.data));
+        setHasMore(json.data.length === 20);
+      }
+    } catch (error) {
+      console.error("Failed to fetch questions:", error);
+    } finally {
+      setLoading(false);
+      setLoadingMore(false);
+    }
+  }
 
   useEffect(() => {
-    async function fetchQuestions() {
-      try {
-        const res = await fetch("/api/questions");
-        const json = await res.json();
-        if (json.data) {
-          setQuestions(json.data);
-        }
-      } catch (error) {
-        console.error("Failed to fetch questions:", error);
-      } finally {
-        setLoading(false);
-      }
-    }
-    fetchQuestions();
+    fetchQuestions(1);
   }, []);
+
+  const handleLoadMore = () => {
+    const nextPage = page + 1;
+    setPage(nextPage);
+    fetchQuestions(nextPage, true);
+  };
 
   return (
     <div
@@ -31,61 +47,73 @@ export default function QuestionsPage() {
       className="flex min-h-screen bg-background flex-col relative"
     >
       <TopNavBar />
-
       <div
         id="questions-content-container"
         className="flex flex-col px-4 sm:px-8 py-8 gap-10 w-full max-w-5xl mx-auto flex-1 overflow-y-auto"
       >
         <div className="w-full flex flex-col gap-6">
           <AskQuestionCard />
-
           {loading ? (
             <div className="flex justify-center py-10">
               <span className="text-gray-500">Loading questions...</span>
             </div>
           ) : (
-            questions.map((q) => (
-              <QuestionCard
-                key={q.question_id}
-                id={q.question_id}
-                demandRate={q.demand_score}
-                questionTitle={q.title}
-                profileURL={q.profile_url}
-                author={q.user_name}
-                subjectTag={q.category.split(",").map((s: string) => s.trim())}
-                createdAt={new Date(q.created_at).toLocaleDateString("en-US", {
-                  month: "short",
-                  day: "numeric",
-                  year: "numeric",
-                })}
-                body={q.content}
-                answers={q.answers.map((a: any) => ({
-                  id: String(a.answer_id),
-                  credibilityScore: a.author_credibility_score || 0,
-                  authorName: a.author_name,
-                  body: a.content,
-                  mediaURLs: a.media_urls,
-                  createdAt: new Date(a.created_at).toLocaleDateString(
-                    "en-US",
-                    {
-                      month: "short",
-                      day: "numeric",
-                      year: "numeric",
-                    },
-                  ),
-                  isResolved: a.is_accepted,
-                  totalComments: 0,
-                  totalUpVotes: 0,
-                  totalDownVotes: 0,
-                  userVote: null,
-                }))}
-                totalUpVotes={0}
-                totalDownVotes={0}
-                onCreateTutorial={(id) =>
-                  console.log("Create tutorial for:", id)
-                }
-              />
-            ))
+            <>
+              {questions.map((q) => (
+                <QuestionCard
+                  key={q.question_id}
+                  id={q.question_id}
+                  demandRate={q.demand_score}
+                  questionTitle={q.title}
+                  profileURL={q.profile_url}
+                  author={q.user_name}
+                  subjectTag={q.category.split(",").map((s: string) => s.trim())}
+                  createdAt={new Date(q.created_at).toLocaleDateString("en-US", {
+                    month: "short",
+                    day: "numeric",
+                    year: "numeric",
+                  })}
+                  body={q.content}
+                  answers={q.answers.map((a: any) => ({
+                    id: String(a.answer_id),
+                    credibilityScore: a.author_credibility_score || 0,
+                    authorName: a.author_name,
+                    body: a.content,
+                    mediaURLs: a.media_urls,
+                    createdAt: new Date(a.created_at).toLocaleDateString(
+                      "en-US",
+                      {
+                        month: "short",
+                        day: "numeric",
+                        year: "numeric",
+                      },
+                    ),
+                    isResolved: a.is_accepted,
+                    totalComments: 0,
+                    totalUpVotes: 0,
+                    totalDownVotes: 0,
+                    userVote: null,
+                  }))}
+                  totalUpVotes={0}
+                  totalDownVotes={0}
+                  onCreateTutorial={(id) =>
+                    console.log("Create tutorial for:", id)
+                  }
+                />
+              ))}
+
+              {hasMore && questions.length > 0 && (
+                <div className="flex justify-center py-6">
+                  <button
+                    onClick={handleLoadMore}
+                    disabled={loadingMore}
+                    className="px-6 py-3 bg-primary-500 text-white rounded-lg hover:bg-primary-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  >
+                    {loadingMore ? "Loading..." : "Load More"}
+                  </button>
+                </div>
+              )}
+            </>
           )}
         </div>
       </div>

--- a/src/app/tutorials/page.tsx
+++ b/src/app/tutorials/page.tsx
@@ -6,23 +6,39 @@ import TutorialCard from "@/components/cards/TutorialCard";
 export default function TutorialsPage() {
   const [tutorials, setTutorials] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [page, setPage] = useState(1);
+  const [hasMore, setHasMore] = useState(true);
+
+  async function fetchTutorials(pageNum: number, append = false) {
+    try {
+      if (!append) setLoading(true);
+      else setLoadingMore(true);
+
+      const res = await fetch(`/api/tutorial?page=${pageNum}&limit=20`);
+      const json = await res.json();
+
+      if (json.data) {
+        setTutorials((prev) => (append ? [...prev, ...json.data] : json.data));
+        setHasMore(json.hasMore ?? false);
+      }
+    } catch (error) {
+      console.error("Failed to fetch tutorials:", error);
+    } finally {
+      setLoading(false);
+      setLoadingMore(false);
+    }
+  }
 
   useEffect(() => {
-    async function fetchTutorials() {
-      try {
-        const res = await fetch("/api/tutorial");
-        const json = await res.json();
-        if (json.data) {
-          setTutorials(json.data);
-        }
-      } catch (error) {
-        console.error("Failed to fetch tutorials:", error);
-      } finally {
-        setLoading(false);
-      }
-    }
-    fetchTutorials();
+    fetchTutorials(1);
   }, []);
+
+  const handleLoadMore = () => {
+    const nextPage = page + 1;
+    setPage(nextPage);
+    fetchTutorials(nextPage, true);
+  };
 
   return (
     <div
@@ -30,7 +46,6 @@ export default function TutorialsPage() {
       className="flex min-h-screen bg-background flex-col relative"
     >
       <TopNavBar />
-
       <div
         id="tutorials-content-container"
         className="flex flex-col px-4 sm:px-8 py-8 gap-10 w-full max-w-5xl mx-auto flex-1 overflow-y-auto"
@@ -41,7 +56,6 @@ export default function TutorialsPage() {
               Tutorials
             </h1>
           </div>
-
           {loading ? (
             <div className="flex justify-center py-10">
               <span className="text-gray-500">Loading tutorials...</span>
@@ -51,25 +65,39 @@ export default function TutorialsPage() {
               <span className="text-gray-500">No tutorials found.</span>
             </div>
           ) : (
-            tutorials.map((t) => (
-              <TutorialCard
-                key={t.tutorial_id}
-                id={t.tutorial_id}
-                title={t.title}
-                content={t.content}
-                author={t.user_name}
-                avatarUrl={t.profile_url}
-                createdAt={new Date(t.created_at).toLocaleDateString("en-US", {
-                  month: "short",
-                  day: "numeric",
-                  year: "numeric",
-                })}
-                avgRating={Number(t.avg_rating) || 0}
-                totalInteractions={Number(t.total_interactions) || 0}
-                videoUrl={t.embedded_video_url}
-                linkedQuestions={t.linked_questions}
-              />
-            ))
+            <>
+              {tutorials.map((t) => (
+                <TutorialCard
+                  key={t.tutorial_id}
+                  id={t.tutorial_id}
+                  title={t.title}
+                  content={t.content}
+                  author={t.user_name}
+                  avatarUrl={t.profile_url}
+                  createdAt={new Date(t.created_at).toLocaleDateString("en-US", {
+                    month: "short",
+                    day: "numeric",
+                    year: "numeric",
+                  })}
+                  avgRating={Number(t.avg_rating) || 0}
+                  totalInteractions={Number(t.total_interactions) || 0}
+                  videoUrl={t.embedded_video_url}
+                  linkedQuestions={t.linked_questions}
+                />
+              ))}
+              
+              {hasMore && (
+                <div className="flex justify-center py-6">
+                  <button
+                    onClick={handleLoadMore}
+                    disabled={loadingMore}
+                    className="px-6 py-3 bg-primary-500 text-white rounded-lg hover:bg-primary-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  >
+                    {loadingMore ? "Loading..." : "Load More"}
+                  </button>
+                </div>
+              )}
+            </>
           )}
         </div>
       </div>


### PR DESCRIPTION
changes
- Added Load More button to tutorials page with page-based pagination
- Added Load More button to questions page with page-based pagination
- Button only shows when more results are available

notes
- API already supported limit/offset, just added frontend pagination controls
- Load More appends new results to existing list
- Loading states handled for both initial load and "load more" action