### PR TITLE
Feat/tutorial material uploads and management

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,6 @@ STORAGE_BACKEND=local
 SUPABASE_URL=
 SUPABASE_SERVICE_ROLE_KEY=
 SUPABASE_STORAGE_BUCKET=tutorial-materials
+
+# Required only for the manual cron HTTP trigger (POST /api/cron/purge-tutorials). Embedded scheduler in server.ts runs in-process and does not need this.
+CRON_SECRET=

--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,11 @@ DB_NAME=studystack
 DB_USER=postgres
 DB_PASSWORD=
 JWT_SECRET=
+
+# Storage backend: local | supabase | s3 (default: local)
+STORAGE_BACKEND=local
+
+# Required when STORAGE_BACKEND=supabase. Service-role key is server-only — never ship to client.
+SUPABASE_URL=
+SUPABASE_SERVICE_ROLE_KEY=
+SUPABASE_STORAGE_BUCKET=tutorial-materials

--- a/docs/tutorials-backend.md
+++ b/docs/tutorials-backend.md
@@ -1,0 +1,75 @@
+# Tutorials Backend
+
+Reference for the tutorials feature's storage, upload, deletion, and retention plumbing. Cross-links the four moving pieces so you don't have to grep for them.
+
+## Pieces
+
+| Concern | Entry point | Notes |
+|---|---|---|
+| Storage abstraction | [src/lib/storage/index.ts](../src/lib/storage/index.ts) | `StorageDriver` interface; `getStorage()` returns the active driver based on `STORAGE_BACKEND`. |
+| Local driver | [src/lib/storage/local.ts](../src/lib/storage/local.ts) | Filesystem-backed. Default for dev. |
+| Supabase driver | [src/lib/storage/supabase.ts](../src/lib/storage/supabase.ts) | Private bucket + signed URLs. Production. |
+| Supabase client | [src/lib/supabase.ts](../src/lib/supabase.ts) | Lazy service-role client, server-only. |
+| Upload (streamed) | [src/app/api/tutorial/[tutorialId]/upload/route.ts](../src/app/api/tutorial/[tutorialId]/upload/route.ts) | busboy → `putStream`, no full-file buffer. |
+| Material DELETE | [src/app/api/tutorial/[tutorialId]/materials/[materialId]/route.ts](../src/app/api/tutorial/[tutorialId]/materials/[materialId]/route.ts) | DB-first, storage cleanup best-effort. |
+| Purge logic | [src/lib/cron/purge-tutorials.ts](../src/lib/cron/purge-tutorials.ts) | `runTutorialPurge()` — sweeps soft-deleted tutorials past `RETENTION_DAYS`. |
+| Cron HTTP trigger | [src/app/api/cron/purge-tutorials/route.ts](../src/app/api/cron/purge-tutorials/route.ts) | Auth-gated by `CRON_SECRET`. Manual / external scheduler. |
+| Embedded cron | [server.ts](../server.ts) | Daily 03:00 in-process via `node-cron`. Skipped when `NODE_ENV=test`. |
+
+## Environment
+
+| Var | Required when | Purpose |
+|---|---|---|
+| `STORAGE_BACKEND` | always | `local` (default) \| `supabase` \| `s3` (stub). |
+| `SUPABASE_URL` | `STORAGE_BACKEND=supabase` | Project URL from Supabase dashboard → Settings → API. |
+| `SUPABASE_SERVICE_ROLE_KEY` | `STORAGE_BACKEND=supabase` | **Server-only.** Service-role key, not anon. Never ship to client. |
+| `SUPABASE_STORAGE_BUCKET` | `STORAGE_BACKEND=supabase` | Bucket name. Defaults to `tutorial-materials`. |
+| `CRON_SECRET` | only for HTTP trigger | Bearer secret for `POST /api/cron/purge-tutorials`. Embedded cron does not use it. |
+
+See [.env.example](../.env.example) for the canonical list.
+
+## Storage backend switching
+
+Keys are scheme-stable (`tutorials/<tutorialId>/<uuid>-<filename>`), so flipping `STORAGE_BACKEND` does not require a migration — but existing objects only live in the backend that wrote them. To migrate, copy objects out of the old backend into the new one preserving keys, then flip the env.
+
+## Upload flow
+
+1. Client `PUT`s multipart to `/api/tutorial/[tutorialId]/upload`.
+2. Route bridges Web `ReadableStream` → Node `Readable` via `Readable.fromWeb`.
+3. busboy parses; on the `file` event, MIME is validated against `DOCUMENT_MIMES` / `VIDEO_MIMES` from [src/lib/validation/tutorial.ts](../src/lib/validation/tutorial.ts) before any bytes are written.
+4. Per-MIME size limit enforced via a Transform passthrough that destroys the stream when bytes exceed `MAX_MATERIAL_BYTES` (docs) or `MAX_VIDEO_BYTES` (videos). busboy's own `fileSize` acts as the upper bound.
+5. Stream piped directly to `storage.putStream(...)` — no intermediate buffer. RSS stays flat regardless of file size.
+6. True uploaded byte count goes into `tutorial_materials.size_bytes` (not the client-declared size).
+7. On insert failure, compensating cleanup deletes the just-uploaded object with the `[Orphan Cleanup]` log tag.
+
+## Deletion flow
+
+`DELETE /api/tutorial/[tutorialId]/materials/[materialId]` is **DB-first, storage best-effort**:
+
+- DB row is removed first. If storage delete fails afterward, it's logged as `[Orphan Cleanup]` and swept by the next purge cron run.
+- Inverting the order risks a successful storage delete with a still-referenced row, which would 200 the client but break their next signed-URL fetch.
+
+Soft-delete of the parent tutorial (`DELETE /api/tutorial/[tutorialId]`) sets `deleted_at`; objects survive until the cron sweeps them.
+
+## Retention / cron
+
+- `RETENTION_DAYS = 30` in [src/lib/cron/purge-tutorials.ts](../src/lib/cron/purge-tutorials.ts).
+- Embedded scheduler in [server.ts](../server.ts) fires daily at 03:00 server time, calls `runTutorialPurge()` directly — no HTTP, no secret.
+- HTTP trigger remains as a manual / external-scheduler hook. Auth: `Authorization: Bearer $CRON_SECRET`.
+- Storage deletes are per-key with try/catch — one failed delete does not abort the sweep. The DB hard-delete runs after storage cleanup.
+
+## Multi-instance deploys
+
+Embedded cron runs in every instance. If you scale beyond one, gate registration on a single-instance env (e.g. `CRON_ENABLED=true`) or disable embedded cron entirely and drive the HTTP endpoint from an external scheduler. Don't run the embedded cron on N instances — you'll get N concurrent purge sweeps fighting over the same rows.
+
+## Adding a backend
+
+1. Implement [src/lib/storage/index.ts](../src/lib/storage/index.ts) `StorageDriver` — `put`, `putStream`, `getUrl`, `delete`. `delete` must be idempotent (missing-object is not an error).
+2. Wire it into the `getStorage()` switch in the same file.
+3. Add an `.env.example` block documenting required env.
+4. Verify both `local` parity and the new backend with the smoke tests in §Verification of the original plan.
+
+## Related docs
+
+- [error-handling.md](./error-handling.md) — `AppError` hierarchy, `errorToResponse`, the `[Orphan Cleanup]` convention.
+- [database-queries-and-transactions.md](./database-queries-and-transactions.md) — `q()` / `tx()` patterns used by `runTutorialPurge` and the material/tutorial queries.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,10 @@
       "version": "0.1.0",
       "dependencies": {
         "@supabase/supabase-js": "^2.105.4",
+        "@types/busboy": "^1.5.4",
         "axios": "^1.15.0",
         "bcrypt": "^6.0.0",
+        "busboy": "^1.6.0",
         "jsonwebtoken": "^9.0.3",
         "lucide-react": "^1.8.0",
         "next": "16.2.4",
@@ -3069,6 +3071,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/busboy": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@types/busboy/-/busboy-1.5.4.tgz",
+      "integrity": "sha512-kG7WrUuAKK0NoyxfQHsVE6j1m01s6kMma64E+OZenQABMQyTJop1DumUWcLwAQ2JzpefU7PDYoRDKl8uZosFjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/cors": {
       "version": "2.8.19",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
@@ -4566,6 +4577,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
       }
     },
     "node_modules/call-bind": {
@@ -9323,6 +9345,14 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/string.prototype.includes": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@supabase/supabase-js": "^2.105.4",
         "@types/busboy": "^1.5.4",
+        "@types/node-cron": "^3.0.11",
         "axios": "^1.15.0",
         "bcrypt": "^6.0.0",
         "busboy": "^1.6.0",
@@ -17,6 +18,7 @@
         "lucide-react": "^1.8.0",
         "next": "16.2.4",
         "next-pwa": "^5.6.0",
+        "node-cron": "^4.2.1",
         "pg": "^8.20.0",
         "react": "19.2.4",
         "react-dom": "19.2.4",
@@ -3172,6 +3174,12 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/node-cron": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/node-cron/-/node-cron-3.0.11.tgz",
+      "integrity": "sha512-0ikrnug3/IyneSHqCBeslAhlK2aBfYek1fGo4bP4QnZPmiqSGRK+Oy7ZMisLWkesffJvQ1cqAcBnJC+8+nxIAg==",
+      "license": "MIT"
     },
     "node_modules/@types/pg": {
       "version": "8.20.0",
@@ -7954,6 +7962,15 @@
       "license": "MIT",
       "engines": {
         "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-cron": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.2.1.tgz",
+      "integrity": "sha512-lgimEHPE/QDgFlywTd8yTR61ptugX3Qer29efeyWw2rv259HtGBNn1vZVmp8lB9uo9wC0t/AT4iGqXxia+CJFg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/node-exports-info": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "studystack",
       "version": "0.1.0",
       "dependencies": {
+        "@supabase/supabase-js": "^2.105.4",
         "axios": "^1.15.0",
         "bcrypt": "^6.0.0",
         "jsonwebtoken": "^9.0.3",
@@ -2633,6 +2634,90 @@
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
       "license": "MIT"
+    },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.105.4",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.105.4.tgz",
+      "integrity": "sha512-Ejfa37M5xoIwoxVebxRahnwubPo8g22qkXQ4p50+N9MIvU9UZoN+A8dwVPtczzGf8oV/YXN80ZPxK4aWXuSN/A==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.105.4",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.105.4.tgz",
+      "integrity": "sha512-JVNKbBft3Qkja+WlGaE026AJ2AH9K0UTsxsfvEIHgd4zFrBor4BYRCrYFrv9IDsvVqkF72wKDsODJl5GY/C4tA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.2.tgz",
+      "integrity": "sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.105.4",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.105.4.tgz",
+      "integrity": "sha512-SppIyLo/kTwIlz1qpv2HN1EQqBg0GVktrDDFsXygYROha3MgVn4rT7p5EjFHFqXQm2rdRGb/BI7bc+jr10m91w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.105.4",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.105.4.tgz",
+      "integrity": "sha512-6ov6c59+8D9h7q4M4Gy/uDJlC0Akxl9/714Y+6vJ+Sijuc16TS/p5DwhfRCLNcIhNiej1gEt+CQUwsjiPt4PxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "^0.4.2",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.105.4",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.105.4.tgz",
+      "integrity": "sha512-Jx+pzMP1Whjof2PWHoVBUA75/p7PQE9CqKBzn1oXVyJDOggMLSH2OzVWwsXYaxEpdC1K/KltwmOX44nL3LHl9g==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.105.4",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.105.4.tgz",
+      "integrity": "sha512-cEnx+k49knU+qdIP7rXwR6fqEXPHZs+74xFK1R0S8MgQ7v9tbePVdGxvO03n3bPympMdJWVLadARBfU4TgNHCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.105.4",
+        "@supabase/functions-js": "2.105.4",
+        "@supabase/postgrest-js": "2.105.4",
+        "@supabase/realtime-js": "2.105.4",
+        "@supabase/storage-js": "2.105.4"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",
@@ -6326,6 +6411,15 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/idb": {

--- a/package.json
+++ b/package.json
@@ -11,8 +11,10 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.105.4",
+    "@types/busboy": "^1.5.4",
     "axios": "^1.15.0",
     "bcrypt": "^6.0.0",
+    "busboy": "^1.6.0",
     "jsonwebtoken": "^9.0.3",
     "lucide-react": "^1.8.0",
     "next": "16.2.4",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "init-db": "ts-node scripts/init-db.ts"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.105.4",
     "axios": "^1.15.0",
     "bcrypt": "^6.0.0",
     "jsonwebtoken": "^9.0.3",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@supabase/supabase-js": "^2.105.4",
     "@types/busboy": "^1.5.4",
+    "@types/node-cron": "^3.0.11",
     "axios": "^1.15.0",
     "bcrypt": "^6.0.0",
     "busboy": "^1.6.0",
@@ -19,6 +20,7 @@
     "lucide-react": "^1.8.0",
     "next": "16.2.4",
     "next-pwa": "^5.6.0",
+    "node-cron": "^4.2.1",
     "pg": "^8.20.0",
     "react": "19.2.4",
     "react-dom": "19.2.4",

--- a/server.ts
+++ b/server.ts
@@ -1,12 +1,26 @@
 import { createServer } from "http";
 import { Server } from "socket.io";
 import next from "next";
+import cron from "node-cron";
+import { runTutorialPurge } from "./src/lib/cron/purge-tutorials";
 
 const dev = process.env.NODE_ENV !== "production";
 const app = next({ dev });
 const handle = app.getRequestHandler();
 
 app.prepare().then(() => {
+  if (process.env.NODE_ENV !== "test") {
+    cron.schedule("0 3 * * *", () => {
+      runTutorialPurge()
+        .then((result) =>
+          console.log(
+            `[purge-tutorials cron] deleted=${result.deleted} files_removed=${result.files_removed}`,
+          ),
+        )
+        .catch((err) => console.error("[purge-tutorials cron]", err));
+    });
+  }
+
   const httpServer = createServer((req, res) => handle(req, res));
 
   const io = new Server(httpServer, {

--- a/src/app/api/cron/purge-tutorials/route.ts
+++ b/src/app/api/cron/purge-tutorials/route.ts
@@ -1,10 +1,6 @@
-import { q } from "@/lib/db";
+import { runTutorialPurge } from "@/lib/cron/purge-tutorials";
 import { AuthError, errorToResponse } from "@/lib/errors";
-import { hardDeleteExpiredTutorials } from "@/lib/queries/tutorials";
-import { getStorage } from "@/lib/storage";
 import { NextRequest, NextResponse } from "next/server";
-
-const RETENTION_DAYS = 30;
 
 export async function POST(request: NextRequest) {
   try {
@@ -18,27 +14,8 @@ export async function POST(request: NextRequest) {
       throw new AuthError("Unauthorized");
     }
 
-    const expiredKeys = await q<{ storage_key: string }>(
-      `SELECT m.storage_key
-       FROM tutorial_materials m
-       JOIN tutorials t ON t.tutorial_id = m.tutorial_id
-       WHERE t.deleted_at IS NOT NULL
-         AND t.deleted_at < now() - ($1 || ' days')::interval`,
-      [RETENTION_DAYS],
-    );
-
-    const storage = getStorage();
-    for (const { storage_key } of expiredKeys) {
-      try {
-        await storage.delete(storage_key);
-      } catch (err) {
-        console.error("[purge-tutorials] file delete failed", storage_key, err);
-      }
-    }
-
-    const deleted = await hardDeleteExpiredTutorials(RETENTION_DAYS);
-
-    return NextResponse.json({ deleted, files_removed: expiredKeys.length });
+    const result = await runTutorialPurge();
+    return NextResponse.json(result);
   } catch (error) {
     return errorToResponse(error);
   }

--- a/src/app/api/tutorial/[tutorialId]/materials/[materialId]/route.ts
+++ b/src/app/api/tutorial/[tutorialId]/materials/[materialId]/route.ts
@@ -1,0 +1,45 @@
+import { withAuth, type AuthedRequest } from "@/lib/auth";
+import { asTutorialId, asTutorialMaterialId } from "@/lib/db-brands";
+import { errorToResponse, ForbiddenError, NotFoundError } from "@/lib/errors";
+import {
+  deleteMaterial,
+  getMaterialById,
+} from "@/lib/queries/tutorial-materials";
+import { getTutorialById } from "@/lib/queries/tutorials";
+import { getStorage } from "@/lib/storage";
+import { NextRequest, NextResponse } from "next/server";
+
+type RouteCtx = {
+  params: Promise<{ tutorialId: string; materialId: string }>;
+};
+
+export const DELETE = (req: NextRequest, ctx: RouteCtx) =>
+  withAuth(async (authedReq: AuthedRequest) => {
+    try {
+      const { tutorialId, materialId } = await ctx.params;
+      const tid = asTutorialId(tutorialId);
+      const mid = asTutorialMaterialId(materialId);
+
+      const tutorial = await getTutorialById(tid);
+      if (!tutorial) throw new NotFoundError("Tutorial not found");
+      if (tutorial.user_id !== authedReq.userId) {
+        throw new ForbiddenError();
+      }
+
+      const material = await getMaterialById(mid);
+      if (!material || material.tutorial_id !== tid) {
+        throw new NotFoundError("Material not found");
+      }
+
+      const removed = await deleteMaterial(mid);
+      if (!removed) throw new NotFoundError("Material not found");
+
+      await getStorage()
+        .delete(material.storage_key)
+        .catch((err) => console.error("[Orphan Cleanup]", err));
+
+      return NextResponse.json({ success: true });
+    } catch (error) {
+      return errorToResponse(error);
+    }
+  })(req);

--- a/src/app/api/tutorial/[tutorialId]/upload/route.ts
+++ b/src/app/api/tutorial/[tutorialId]/upload/route.ts
@@ -11,17 +11,132 @@ import { getTutorialById } from "@/lib/queries/tutorials";
 import { DEFAULT_URL_TTL_SECONDS, getStorage } from "@/lib/storage";
 import {
   DOCUMENT_MIMES,
-  validateMaterialFile,
-  validateVideoFile,
+  MAX_MATERIAL_BYTES,
+  MAX_VIDEO_BYTES,
   VIDEO_MIMES,
 } from "@/lib/validation/tutorial";
+import Busboy from "busboy";
 import { randomUUID } from "crypto";
 import { NextRequest, NextResponse } from "next/server";
+import { Readable, Transform } from "stream";
 
 type RouteCtx = { params: Promise<{ tutorialId: string }> };
 
+type UploadResult = {
+  key: string;
+  mime: string;
+  size: number;
+  fileName: string;
+};
+
 function sanitizeFileName(name: string): string {
   return name.replace(/[^A-Za-z0-9._-]/g, "_").slice(0, 200) || "file";
+}
+
+async function streamUploadToStorage(
+  req: AuthedRequest,
+  tid: ReturnType<typeof asTutorialId>,
+): Promise<UploadResult> {
+  const ct = req.headers.get("content-type");
+  if (!ct || !ct.toLowerCase().includes("multipart/form-data")) {
+    throw new ValidationError("Expected multipart/form-data");
+  }
+  if (!req.body) {
+    throw new ValidationError("Missing request body");
+  }
+
+  const storage = getStorage();
+  const bb = Busboy({
+    headers: { "content-type": ct },
+    limits: { files: 1, fileSize: MAX_VIDEO_BYTES },
+  });
+
+  return new Promise<UploadResult>((resolve, reject) => {
+    let handled = false;
+    let settled = false;
+    const finish = (err?: Error, value?: UploadResult) => {
+      if (settled) return;
+      settled = true;
+      if (err) reject(err);
+      else resolve(value as UploadResult);
+    };
+
+    bb.on("file", (_name, file, info) => {
+      if (handled) {
+        file.resume();
+        return;
+      }
+      handled = true;
+
+      const mime = info.mimeType || "application/octet-stream";
+      const isVideo = (VIDEO_MIMES as readonly string[]).includes(mime);
+      const isDoc = (DOCUMENT_MIMES as readonly string[]).includes(mime);
+      if (!isVideo && !isDoc) {
+        file.resume();
+        finish(new ValidationError(`Unsupported file type: ${mime}`));
+        return;
+      }
+
+      const limit = isVideo ? MAX_VIDEO_BYTES : MAX_MATERIAL_BYTES;
+      const fileName = info.filename || "file";
+      const safeName = sanitizeFileName(fileName);
+      const key = `tutorials/${tid}/${randomUUID()}-${safeName}`;
+
+      let bytes = 0;
+      const counter = new Transform({
+        transform(chunk, _enc, cb) {
+          bytes += chunk.length;
+          if (bytes > limit) {
+            cb(new ValidationError(`File exceeds size limit (${limit} bytes)`));
+            return;
+          }
+          cb(null, chunk);
+        },
+      });
+
+      file.on("limit", () => {
+        counter.destroy(
+          new ValidationError(`File exceeds size limit (${limit} bytes)`),
+        );
+      });
+
+      file.pipe(counter);
+
+      storage
+        .putStream({ key, stream: counter, mimeType: mime })
+        .then(() => {
+          if (bytes <= 0) {
+            storage
+              .delete(key)
+              .catch((err) => console.error("[Orphan Cleanup]", err));
+            finish(new ValidationError("Empty file"));
+            return;
+          }
+          finish(undefined, { key, mime, size: bytes, fileName });
+        })
+        .catch((err) => {
+          storage
+            .delete(key)
+            .catch((cleanupErr) =>
+              console.error("[Orphan Cleanup]", cleanupErr),
+            );
+          finish(err instanceof Error ? err : new Error(String(err)));
+        });
+    });
+
+    bb.on("error", (err) =>
+      finish(err instanceof Error ? err : new Error(String(err))),
+    );
+    bb.on("close", () => {
+      if (!handled) finish(new ValidationError("Missing 'file' in form data"));
+    });
+
+    Readable.fromWeb(req.body as Parameters<typeof Readable.fromWeb>[0])
+      .pipe(bb)
+      .on("error", (err) =>
+        finish(err instanceof Error ? err : new Error(String(err))),
+      );
+  });
 }
 
 export const PUT = (req: NextRequest, ctx: RouteCtx) =>
@@ -36,39 +151,18 @@ export const PUT = (req: NextRequest, ctx: RouteCtx) =>
         throw new AuthError("Forbidden");
       }
 
-      const formData = await authedReq.formData();
-      const fileEntry = formData.get("file");
-      if (!(fileEntry instanceof File)) {
-        throw new ValidationError("Missing 'file' in form data");
-      }
-
-      const mime = fileEntry.type || "application/octet-stream";
-      const size = fileEntry.size;
-
-      if ((VIDEO_MIMES as readonly string[]).includes(mime)) {
-        validateVideoFile(mime, size);
-      } else if ((DOCUMENT_MIMES as readonly string[]).includes(mime)) {
-        validateMaterialFile(mime, size);
-      } else {
-        throw new ValidationError(`Unsupported file type: ${mime}`);
-      }
+      const upload = await streamUploadToStorage(authedReq, tid);
 
       const storage = getStorage();
-      const safeName = sanitizeFileName(fileEntry.name);
-      const key = `tutorials/${tid}/${randomUUID()}-${safeName}`;
-      const buffer = Buffer.from(await fileEntry.arrayBuffer());
-
-      await storage.put({ key, buffer, mimeType: mime });
-
       const material = await insertTutorialMaterial({
         tutorial_id: tid,
-        file_name: fileEntry.name,
-        storage_key: key,
-        mime_type: mime,
-        size_bytes: size,
+        file_name: upload.fileName,
+        storage_key: upload.key,
+        mime_type: upload.mime,
+        size_bytes: upload.size,
       }).catch(async (insertErr) => {
         await storage
-          .delete(key)
+          .delete(upload.key)
           .catch((cleanupErr) =>
             console.error("[Orphan Cleanup]", cleanupErr),
           );
@@ -76,7 +170,7 @@ export const PUT = (req: NextRequest, ctx: RouteCtx) =>
       });
 
       const ttl = DEFAULT_URL_TTL_SECONDS;
-      const url = await storage.getUrl(key, { expiresIn: ttl });
+      const url = await storage.getUrl(upload.key, { expiresIn: ttl });
       const expires_at = new Date(Date.now() + ttl * 1000).toISOString();
 
       return NextResponse.json(

--- a/src/lib/cron/purge-tutorials.ts
+++ b/src/lib/cron/purge-tutorials.ts
@@ -1,0 +1,31 @@
+import "server-only";
+import { q } from "@/lib/db";
+import { hardDeleteExpiredTutorials } from "@/lib/queries/tutorials";
+import { getStorage } from "@/lib/storage";
+
+export const RETENTION_DAYS = 30;
+
+export type PurgeResult = { deleted: number; files_removed: number };
+
+export async function runTutorialPurge(): Promise<PurgeResult> {
+  const expiredKeys = await q<{ storage_key: string }>(
+    `SELECT m.storage_key
+     FROM tutorial_materials m
+     JOIN tutorials t ON t.tutorial_id = m.tutorial_id
+     WHERE t.deleted_at IS NOT NULL
+       AND t.deleted_at < now() - ($1 || ' days')::interval`,
+    [RETENTION_DAYS],
+  );
+
+  const storage = getStorage();
+  for (const { storage_key } of expiredKeys) {
+    try {
+      await storage.delete(storage_key);
+    } catch (err) {
+      console.error("[purge-tutorials] file delete failed", storage_key, err);
+    }
+  }
+
+  const deleted = await hardDeleteExpiredTutorials(RETENTION_DAYS);
+  return { deleted, files_removed: expiredKeys.length };
+}

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -11,6 +11,12 @@ export interface StorageDriver {
     buffer: Buffer;
     mimeType: string;
   }): Promise<string>;
+  putStream(opts: {
+    key: string;
+    stream: NodeJS.ReadableStream;
+    mimeType: string;
+    contentLength?: number;
+  }): Promise<string>;
   getUrl(key: string, opts?: { expiresIn?: number }): Promise<string>;
   delete(key: string): Promise<void>;
 }

--- a/src/lib/storage/local.ts
+++ b/src/lib/storage/local.ts
@@ -1,6 +1,7 @@
 import "server-only";
-import { promises as fs } from "fs";
+import { createWriteStream, promises as fs } from "fs";
 import path from "path";
+import { pipeline } from "stream/promises";
 import jwt from "jsonwebtoken";
 import { JWT_SECRET } from "@/lib/auth";
 import { AuthError } from "@/lib/errors";
@@ -41,6 +42,18 @@ export const localStorage: StorageDriver = {
     const target = resolveSafe(key);
     await fs.mkdir(path.dirname(target), { recursive: true });
     await fs.writeFile(target, buffer);
+    return key;
+  },
+
+  async putStream({ key, stream }) {
+    const target = resolveSafe(key);
+    await fs.mkdir(path.dirname(target), { recursive: true });
+    try {
+      await pipeline(stream, createWriteStream(target));
+    } catch (err) {
+      await fs.rm(target, { force: true }).catch(() => {});
+      throw err;
+    }
     return key;
   },
 

--- a/src/lib/storage/local.ts
+++ b/src/lib/storage/local.ts
@@ -51,7 +51,9 @@ export const localStorage: StorageDriver = {
     try {
       await pipeline(stream, createWriteStream(target));
     } catch (err) {
-      await fs.rm(target, { force: true }).catch(() => {});
+      await fs.rm(target, { force: true }).catch((cleanupErr) =>
+        console.error("[Orphan Cleanup]", cleanupErr)
+      );
       throw err;
     }
     return key;

--- a/src/lib/storage/s3.ts
+++ b/src/lib/storage/s3.ts
@@ -5,6 +5,9 @@ export const s3Storage: StorageDriver = {
   async put() {
     throw new Error("s3 storage not configured");
   },
+  async putStream() {
+    throw new Error("s3 storage not configured");
+  },
   async getUrl() {
     throw new Error("s3 storage not configured");
   },

--- a/src/lib/storage/supabase.ts
+++ b/src/lib/storage/supabase.ts
@@ -1,17 +1,56 @@
 import "server-only";
-import type { StorageDriver } from "@/lib/storage";
+import {
+  getSupabaseServiceClient,
+  SUPABASE_STORAGE_BUCKET,
+} from "@/lib/supabase";
+import {
+  DEFAULT_URL_TTL_SECONDS,
+  type StorageDriver,
+} from "@/lib/storage";
+
+function bucket() {
+  return getSupabaseServiceClient().storage.from(SUPABASE_STORAGE_BUCKET);
+}
 
 export const supabaseStorage: StorageDriver = {
-  async put() {
-    throw new Error("supabase storage not configured");
+  async put({ key, buffer, mimeType }) {
+    const { error } = await bucket().upload(key, buffer, {
+      contentType: mimeType,
+      upsert: false,
+    });
+    if (error) throw new Error(`supabase upload failed: ${error.message}`);
+    return key;
   },
-  async putStream() {
-    throw new Error("supabase storage not configured");
+
+  async putStream({ key, stream, mimeType, contentLength }) {
+    const { error } = await bucket().upload(
+      key,
+      stream as unknown as Blob,
+      {
+        contentType: mimeType,
+        upsert: false,
+        ...(contentLength !== undefined ? { duplex: "half" } : {}),
+      } as Parameters<ReturnType<typeof bucket>["upload"]>[2],
+    );
+    if (error) throw new Error(`supabase upload failed: ${error.message}`);
+    return key;
   },
-  async getUrl() {
-    throw new Error("supabase storage not configured");
+
+  async getUrl(key, opts) {
+    const expiresIn = opts?.expiresIn ?? DEFAULT_URL_TTL_SECONDS;
+    const { data, error } = await bucket().createSignedUrl(key, expiresIn);
+    if (error || !data?.signedUrl) {
+      throw new Error(
+        `supabase signed url failed: ${error?.message ?? "no url returned"}`,
+      );
+    }
+    return data.signedUrl;
   },
-  async delete() {
-    throw new Error("supabase storage not configured");
+
+  async delete(key) {
+    const { error } = await bucket().remove([key]);
+    if (error && !/not.*found/i.test(error.message)) {
+      throw new Error(`supabase delete failed: ${error.message}`);
+    }
   },
 };

--- a/src/lib/storage/supabase.ts
+++ b/src/lib/storage/supabase.ts
@@ -5,6 +5,9 @@ export const supabaseStorage: StorageDriver = {
   async put() {
     throw new Error("supabase storage not configured");
   },
+  async putStream() {
+    throw new Error("supabase storage not configured");
+  },
   async getUrl() {
     throw new Error("supabase storage not configured");
   },

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,0 +1,29 @@
+import "server-only";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+let cachedClient: SupabaseClient | null = null;
+
+export function getSupabaseServiceClient(): SupabaseClient {
+  if (cachedClient) return cachedClient;
+
+  const url = process.env.SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!url || !serviceRoleKey) {
+    throw new Error(
+      "Supabase service client requires SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY",
+    );
+  }
+
+  cachedClient = createClient(url, serviceRoleKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  });
+
+  return cachedClient;
+}
+
+export const SUPABASE_STORAGE_BUCKET =
+  process.env.SUPABASE_STORAGE_BUCKET || "tutorial-materials";


### PR DESCRIPTION
## Summary

Closes the four remaining backend gaps on the tutorials feature now that the storage decision has landed on Supabase Storage. Six commits, each independently revertable; `STORAGE_BACKEND=local` continues to work end-to-end at every commit so the change is reversible if Supabase rollout is delayed.

- **`putStream` added to `StorageDriver`** in `src/lib/storage/index.ts` — additive interface change; `local` driver implements it via `fs.createWriteStream` + `pipeline()` with partial-file cleanup, `s3` stub conforms but still throws "not configured". No call-sites change in this commit, so existing `put()` callers stay untouched.
- **Supabase driver, real implementation** in `src/lib/storage/supabase.ts` replacing the throwing stubs. New `src/lib/supabase.ts` lazily memoizes a service-role client on first use (not at import time, so other backends still boot without `SUPABASE_*` vars set). `import 'server-only'` guards against client-bundle leakage of the service-role key. Bucket name from `SUPABASE_STORAGE_BUCKET` (defaults to `tutorial-materials`). `delete` is idempotent — missing-object swallowed to match the `local` driver's `fs.rm({ force: true })` semantics. `getUrl` returns absolute `createSignedUrl` strings; the materials route already sets `Cache-Control: private, max-age=ttl`.
- **Streamed uploads via busboy** in `src/app/api/tutorial/[tutorialId]/upload/route.ts` — replaces `await req.formData()` (which buffered the entire 500 MB video into memory) with a busboy parser fed by `Readable.fromWeb(req.body)`. MIME validated on the `file` event *before* any bytes write. Per-MIME size limit (`MAX_MATERIAL_BYTES` for docs, `MAX_VIDEO_BYTES` for videos) enforced via a Transform passthrough that destroys the stream when exceeded; busboy's own `fileSize` acts as the upper bound. True uploaded byte count goes into `tutorial_materials.size_bytes`, not the client-declared size. Compensating cleanup on partial upload and on insert failure tagged `[Orphan Cleanup]` per the convention in `docs/error-handling.md`. Response shape (`{ ...material, url, expires_at }`, status 201) is unchanged.
- **Material DELETE handler** at `src/app/api/tutorial/[tutorialId]/materials/[materialId]/route.ts` — mirrors the existing tutorial DELETE pattern: `withAuth` → branded-ID coercion → ownership check → `getMaterialById` → `deleteMaterial` → best-effort `storage.delete`. Intentionally **DB-first**: a failed storage delete must not roll back the row, since the next purge sweep will catch the orphan, whereas the inverse risks a 200 to the client followed by broken signed URLs.
- **Retention cron extracted + scheduled in-process** — purge body lifted out of the route into `src/lib/cron/purge-tutorials.ts` as `runTutorialPurge(): Promise<{ deleted, files_removed }>`. The HTTP handler at `src/app/api/cron/purge-tutorials/route.ts` shrinks to auth-gate + delegate, kept around as a manual / external-scheduler hook. `server.ts` registers `cron.schedule('0 3 * * *', ...)` after `app.prepare()`, skipped when `NODE_ENV=test`, errors logged not thrown so a job failure can't crash the server. `RETENTION_DAYS = 30` lives next to the function.
- **Env + ops doc** — `.env.example` now lists `STORAGE_BACKEND`, `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_STORAGE_BUCKET`, and `CRON_SECRET` with comments calling out the server-only / HTTP-trigger-only constraints. New `docs/tutorials-backend.md` cross-links the storage drivers, upload pipeline, deletion contract, retention cron, and multi-instance gotcha so future contributors don't grep for them.

### What's intentionally deferred

- **S3 driver implementation** — stays a stub that conforms to the `putStream` interface. The decision has landed on Supabase; resurrecting S3 would be a separate issue.
- **Frontend wiring of material DELETE** — backend-only this round. UI follow-up PR.
- **Supabase RLS policies on the bucket** — service-role key bypasses RLS, so this isn't a correctness gap, but defense-in-depth (so a misused anon key still can't read) is worth a separate issue.
- **Multi-instance cron gating** — embedded `node-cron` runs in every process. If the deployment scales beyond one instance, gate registration on a single-instance env (`CRON_ENABLED=true`) or disable embedded cron and drive the HTTP endpoint externally. Documented in `docs/tutorials-backend.md` but no code change yet.

### Rollback strategy

- Revert **#2** (`feat(storage): implement Supabase Storage driver`) only if Supabase config slips — `STORAGE_BACKEND=local` still works because #1 and #3 implement `putStream` against the local driver too.
- Revert **#3** (`refactor(tutorials): stream uploads via busboy`) only if the streaming path regresses — falls back to the old `formData()` upload, leaves `putStream` defined-but-unused (harmless).
- **#1**, **#4**, **#5** are zero-risk in isolation.
- Cron job (#5) can be disabled at runtime by setting `NODE_ENV=test`-equivalent without a code revert.

### Relation to prior work

Builds on the tutorials feature merged via #44 (`feat: implement tutorial detail view`) and the established storage abstraction. The branded-ID + typed-error patterns from the earlier database PR (`AppError` hierarchy, `errorToResponse`, `asTutorialId` / `asTutorialMaterialId`) are reused unchanged — this PR adds new entries to those existing systems rather than reshaping them.
