### PR TITLE
Feat/finalize tutorial storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,7 @@ STORAGE_BACKEND=local
 # Required when STORAGE_BACKEND=supabase. Service-role key is server-only — never ship to client.
 SUPABASE_URL=
 SUPABASE_SERVICE_ROLE_KEY=
+# Bucket must be private; set its file-size limit to 50 MB to match MAX_VIDEO_BYTES.
 SUPABASE_STORAGE_BUCKET=tutorial-materials
 
 # Required only for the manual cron HTTP trigger (POST /api/cron/purge-tutorials). Embedded scheduler in server.ts runs in-process and does not need this.

--- a/docs/tutorials-backend.md
+++ b/docs/tutorials-backend.md
@@ -28,6 +28,23 @@ Reference for the tutorials feature's storage, upload, deletion, and retention p
 
 See [.env.example](../.env.example) for the canonical list.
 
+## Supabase bucket setup (manual)
+
+The code side is already wired (`getStorage()` switch, typed errors, env vars in `.env.example`).
+These steps must be done in the Supabase dashboard — they can't be scripted from the repo:
+
+1. Create a **private** bucket named `tutorial-materials` (or whatever `SUPABASE_STORAGE_BUCKET`
+   is set to). Keep it private — public buckets bypass the signed-URL access model.
+2. Set the bucket's file-size limit to **50 MB** to match `MAX_VIDEO_BYTES`.
+3. Restrict allowed MIME types to the union of `DOCUMENT_MIMES` + `VIDEO_MIMES` from
+   [src/lib/validation/tutorial.ts](../src/lib/validation/tutorial.ts).
+4. No storage RLS policies are required: the server uses the **service-role key**, which bypasses
+   RLS. Access control is the private bucket + short-lived signed URLs.
+5. In `.env.local`, set `STORAGE_BACKEND=supabase`, `SUPABASE_URL`, and
+   `SUPABASE_SERVICE_ROLE_KEY` (from dashboard → Settings → API).
+6. Smoke-test with the `/tutorialTest` harness: create a tutorial, upload a file, confirm the
+   object appears in the bucket and the returned signed URL resolves.
+
 ## Storage backend switching
 
 Keys are scheme-stable (`tutorials/<tutorialId>/<uuid>-<filename>`), so flipping `STORAGE_BACKEND` does not require a migration — but existing objects only live in the backend that wrote them. To migrate, copy objects out of the old backend into the new one preserving keys, then flip the env.
@@ -41,6 +58,16 @@ Keys are scheme-stable (`tutorials/<tutorialId>/<uuid>-<filename>`), so flipping
 5. Stream piped directly to `storage.putStream(...)` — no intermediate buffer. RSS stays flat regardless of file size.
 6. True uploaded byte count goes into `tutorial_materials.size_bytes` (not the client-declared size).
 7. On insert failure, compensating cleanup deletes the just-uploaded object with the `[Orphan Cleanup]` log tag.
+
+## Video strategy
+
+Prefer `embedded_video_url` over uploaded video files. The whitelist in
+[src/lib/validation/tutorial.ts](../src/lib/validation/tutorial.ts) (`validateVideoUrl`) accepts
+YouTube / Vimeo / Loom links — no storage cost, no size ceiling, and the host does the
+transcoding.
+
+Uploaded video files remain supported as a fallback but are capped at `MAX_VIDEO_BYTES = 50 MB`
+to stay under the Supabase free-tier per-object limit. If you need larger video, use an embed.
 
 ## Deletion flow
 

--- a/src/app/api/comments/[commentId]/route.ts
+++ b/src/app/api/comments/[commentId]/route.ts
@@ -4,7 +4,8 @@ import { deleteComment } from "@/lib/queries/comments";
 import { NextResponse } from "next/server";
 import { asCommentId } from "@/lib/db-brands";
 
-export const DELETE = withAuth(async (req: AuthedRequest, { params }: { params: { commentId: string } }) => {
+export const DELETE = withAuth(async (req: AuthedRequest, ctx?: unknown) => {
+  const { params } = ctx as { params: { commentId: string } };
   try {
     const success = await deleteComment(asCommentId(parseInt(params.commentId)), req.userId);
     if (!success) {

--- a/src/app/tutorialTest/_TutorialTestHarness.tsx
+++ b/src/app/tutorialTest/_TutorialTestHarness.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+/* TEMP TEST HARNESS — REMOVE ONCE TUTORIAL BACKEND FLOW IS VERIFIED */
+
+import { useState } from "react";
+import FullButton from "@/components/inputs/FullButton";
+import TextInput from "@/components/inputs/TextInput";
+
+function authHeaders(): Record<string, string> {
+  const token =
+    typeof window !== "undefined" ? localStorage.getItem("token") : null;
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+export default function TutorialTestHarness() {
+  const [title, setTitle] = useState("Test tutorial");
+  const [content, setContent] = useState("Test tutorial content body.");
+  const [questionId, setQuestionId] = useState("");
+  const [tutorialId, setTutorialId] = useState("");
+  const [file, setFile] = useState<File | null>(null);
+  const [log, setLog] = useState<string>("");
+  const [busy, setBusy] = useState(false);
+
+  function append(label: string, data: unknown) {
+    setLog(
+      (prev) =>
+        `${prev}\n[${new Date().toLocaleTimeString()}] ${label}\n${JSON.stringify(
+          data,
+          null,
+          2,
+        )}\n`,
+    );
+  }
+
+  async function createTutorial() {
+    setBusy(true);
+    try {
+      const res = await fetch("/api/tutorial", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...authHeaders() },
+        body: JSON.stringify({
+          title,
+          content,
+          question_ids: [questionId],
+        }),
+      });
+      const body = await res.json().catch(() => ({}));
+      append(`POST /api/tutorial → ${res.status}`, body);
+      if (res.ok && body.tutorial?.tutorial_id)
+        setTutorialId(body.tutorial.tutorial_id);
+    } catch (err) {
+      append("POST /api/tutorial → error", String(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function uploadFile() {
+    if (!tutorialId || !file) {
+      append("upload skipped", "need a tutorialId and a selected file");
+      return;
+    }
+    setBusy(true);
+    try {
+      const fd = new FormData();
+      fd.append("file", file);
+      const res = await fetch(`/api/tutorial/${tutorialId}/upload`, {
+        method: "PUT",
+        headers: authHeaders(),
+        body: fd,
+      });
+      const body = await res.json().catch(() => ({}));
+      append(`PUT /api/tutorial/${tutorialId}/upload → ${res.status}`, body);
+    } catch (err) {
+      append("PUT upload → error", String(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function fetchTutorial() {
+    if (!tutorialId) {
+      append("fetch skipped", "need a tutorialId");
+      return;
+    }
+    setBusy(true);
+    try {
+      const res = await fetch(`/api/tutorial/${tutorialId}`, {
+        headers: authHeaders(),
+      });
+      const body = await res.json().catch(() => ({}));
+      append(`GET /api/tutorial/${tutorialId} → ${res.status}`, body);
+    } catch (err) {
+      append("GET tutorial → error", String(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <section className="border-4 border-dashed border-red-500 bg-red-50 p-6 my-10 flex flex-col gap-4">
+      <h2 className="text-lg font-bold text-red-700">
+        ⚠️ TEMP TUTORIAL BACKEND TEST HARNESS — DELETE BEFORE MERGE ⚠️
+      </h2>
+      <p className="text-xs text-red-600">
+        Exercises POST /api/tutorial → PUT upload → GET tutorial. Requires a
+        logged-in token in localStorage and a valid question UUID.
+      </p>
+
+      <TextInput
+        name="harness-title"
+        placeholder="Tutorial title"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+      />
+      <TextInput
+        name="harness-content"
+        placeholder="Tutorial content"
+        multiline
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+      />
+      <TextInput
+        name="harness-question-id"
+        placeholder="Source question UUID"
+        value={questionId}
+        onChange={(e) => setQuestionId(e.target.value)}
+      />
+      <FullButton
+        label="1. Create tutorial"
+        onClick={createTutorial}
+        isLoading={busy}
+      />
+
+      <TextInput
+        name="harness-tutorial-id"
+        placeholder="Tutorial UUID (auto-filled after create)"
+        value={tutorialId}
+        onChange={(e) => setTutorialId(e.target.value)}
+      />
+      <input
+        type="file"
+        onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+        className="text-sm"
+      />
+      <FullButton
+        label="2. Upload material/video"
+        onClick={uploadFile}
+        isLoading={busy}
+      />
+      <FullButton
+        label="3. Fetch tutorial"
+        onClick={fetchTutorial}
+        isLoading={busy}
+        variant="secondary"
+      />
+
+      <pre className="bg-white text-xs p-3 rounded border border-red-300 overflow-auto max-h-80 whitespace-pre-wrap">
+        {log || "(no calls yet)"}
+      </pre>
+    </section>
+  );
+}

--- a/src/app/tutorialTest/page.tsx
+++ b/src/app/tutorialTest/page.tsx
@@ -1,0 +1,11 @@
+/* TEMP TEST HARNESS ROUTE — DELETE THIS FOLDER ONCE TUTORIAL BACKEND FLOW IS VERIFIED */
+
+import TutorialTestHarness from "./_TutorialTestHarness";
+
+export default function TutorialTestPage() {
+  return (
+    <div className="max-w-3xl mx-auto p-6">
+      <TutorialTestHarness />
+    </div>
+  );
+}

--- a/src/app/tutorials/create/page.tsx
+++ b/src/app/tutorials/create/page.tsx
@@ -80,7 +80,9 @@ function CreateTutorialForm() {
         <p className="text-sm text-muted-foreground">
           Tutorial editor form goes here. On submit, POST /api/tutorial with
           the title, content, optional embedded_video_url, and{" "}
-          <code>question_ids: [&quot;{questionId}&quot;]</code>.
+          <code>question_ids: [&quot;{questionId}&quot;]</code>. For video,
+          prefer an embedded YouTube/Vimeo/Loom link over a file upload —
+          uploaded video files are capped at 50 MB.
         </p>
       )}
     </div>

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -9,7 +9,7 @@ export const JWT_SECRET =
 const SALT_ROUNDS = 10;
 
 export type AuthedRequest = NextRequest & { userId: UserID };
-type RouteHandler = (req: AuthedRequest, context: any) => Promise<NextResponse>;
+type RouteHandler = (req: AuthedRequest, context?: unknown) => Promise<NextResponse>;
 
 export async function hashPassword(password: string): Promise<string> {
   return bcrypt.hash(password, SALT_ROUNDS);
@@ -27,7 +27,7 @@ export function generateToken(userId: UserID): string {
 }
 
 export function withAuth(handler: RouteHandler) {
-  return async (req: NextRequest, context: any): Promise<NextResponse> => {
+  return async (req: NextRequest, context?: unknown): Promise<NextResponse> => {
     const authHeader = req.headers.get("authorization");
 
     if (!authHeader?.startsWith("Bearer ")) {

--- a/src/lib/socket.ts
+++ b/src/lib/socket.ts
@@ -1,5 +1,7 @@
+import { DatabaseError } from "@/lib/errors";
+
 export function getIO() {
   const io = (global as any).io;
-  if (!io) throw new Error("Socket.io not initialized");
+  if (!io) throw new DatabaseError("Socket.io not initialized");
   return io;
 }

--- a/src/lib/storage/local.ts
+++ b/src/lib/storage/local.ts
@@ -3,7 +3,7 @@ import path from "path";
 import { pipeline } from "stream/promises";
 import jwt from "jsonwebtoken";
 import { JWT_SECRET } from "@/lib/auth";
-import { AuthError } from "@/lib/errors";
+import { AuthError, ValidationError } from "@/lib/errors";
 import {
   DEFAULT_URL_TTL_SECONDS,
   type StorageDriver,
@@ -31,7 +31,7 @@ function resolveSafe(key: string): string {
   const target = path.resolve(UPLOADS_ROOT, key);
   const root = path.resolve(UPLOADS_ROOT);
   if (target !== root && !target.startsWith(root + path.sep)) {
-    throw new Error("Invalid storage key (path traversal)");
+    throw new ValidationError("Invalid storage key");
   }
   return target;
 }

--- a/src/lib/storage/s3.ts
+++ b/src/lib/storage/s3.ts
@@ -1,16 +1,17 @@
 import type { StorageDriver } from "@/lib/storage";
+import { DatabaseError } from "@/lib/errors";
 
 export const s3Storage: StorageDriver = {
   async put() {
-    throw new Error("s3 storage not configured");
+    throw new DatabaseError("S3 storage not configured");
   },
   async putStream() {
-    throw new Error("s3 storage not configured");
+    throw new DatabaseError("S3 storage not configured");
   },
   async getUrl() {
-    throw new Error("s3 storage not configured");
+    throw new DatabaseError("S3 storage not configured");
   },
   async delete() {
-    throw new Error("s3 storage not configured");
+    throw new DatabaseError("S3 storage not configured");
   },
 };

--- a/src/lib/storage/supabase.ts
+++ b/src/lib/storage/supabase.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_URL_TTL_SECONDS,
   type StorageDriver,
 } from "@/lib/storage";
+import { DatabaseError } from "@/lib/errors";
 
 function bucket() {
   return getSupabaseServiceClient().storage.from(SUPABASE_STORAGE_BUCKET);
@@ -17,7 +18,7 @@ export const supabaseStorage: StorageDriver = {
       contentType: mimeType,
       upsert: false,
     });
-    if (error) throw new Error(`supabase upload failed: ${error.message}`);
+    if (error) throw new DatabaseError(`supabase upload failed: ${error.message}`);
     return key;
   },
 
@@ -31,7 +32,7 @@ export const supabaseStorage: StorageDriver = {
         ...(contentLength !== undefined ? { duplex: "half" } : {}),
       } as Parameters<ReturnType<typeof bucket>["upload"]>[2],
     );
-    if (error) throw new Error(`supabase upload failed: ${error.message}`);
+    if (error) throw new DatabaseError(`supabase upload failed: ${error.message}`);
     return key;
   },
 
@@ -39,7 +40,7 @@ export const supabaseStorage: StorageDriver = {
     const expiresIn = opts?.expiresIn ?? DEFAULT_URL_TTL_SECONDS;
     const { data, error } = await bucket().createSignedUrl(key, expiresIn);
     if (error || !data?.signedUrl) {
-      throw new Error(
+      throw new DatabaseError(
         `supabase signed url failed: ${error?.message ?? "no url returned"}`,
       );
     }
@@ -49,7 +50,7 @@ export const supabaseStorage: StorageDriver = {
   async delete(key) {
     const { error } = await bucket().remove([key]);
     if (error && !/not.*found/i.test(error.message)) {
-      throw new Error(`supabase delete failed: ${error.message}`);
+      throw new DatabaseError(`supabase delete failed: ${error.message}`);
     }
   },
 };

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,4 +1,5 @@
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { DatabaseError } from "@/lib/errors";
 
 let cachedClient: SupabaseClient | null = null;
 
@@ -9,7 +10,7 @@ export function getSupabaseServiceClient(): SupabaseClient {
   const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
   if (!url || !serviceRoleKey) {
-    throw new Error(
+    throw new DatabaseError(
       "Supabase service client requires SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY",
     );
   }

--- a/src/lib/validation/tutorial.ts
+++ b/src/lib/validation/tutorial.ts
@@ -35,7 +35,7 @@ export const ALLOWED_VIDEO_HOSTS = [
 ] as const;
 
 export const MAX_MATERIAL_BYTES = 10 * 1024 * 1024;
-export const MAX_VIDEO_BYTES = 500 * 1024 * 1024;
+export const MAX_VIDEO_BYTES = 50 * 1024 * 1024;
 
 export const createTutorialSchema = z.object({
   title: z.string().min(1).max(255),


### PR DESCRIPTION
## Summary

Finalizes the tutorial file-storage feature: routes infrastructure failures through the typed error hierarchy so they reach the client with proper codes, tightens the uploaded-video size limit to fit the Supabase free tier, and documents the manual Supabase bucket setup.

- **Typed errors across storage/infra modules** — `src/lib/storage/{supabase,s3,local}.ts`, `src/lib/supabase.ts`, and `src/lib/socket.ts` threw bare `new Error(...)`, which `errorToResponse` could only map to a generic `500 INTERNAL_ERROR`. All upload/signed-URL/delete failures, the S3 stub, the missing-env guard, and the socket accessor now throw `DatabaseError` so the response carries a real `code` and status. The local driver's path-traversal guard throws `ValidationError` (`400`) instead — it validates malicious user-supplied keys, not an internal fault.
- **Video upload cap lowered to 50MB** — `MAX_VIDEO_BYTES` in `src/lib/validation/tutorial.ts` drops from 500MB to 50MB to stay under the Supabase free-tier per-object limit. The busboy `fileSize` limit and the Transform byte counter both reference the constant, so the change propagates without further edits. Create-page copy and `docs/tutorials-backend.md` now steer users toward `embedded_video_url` (YouTube/Vimeo/Loom, already host-whitelisted) over file uploads.
- **Supabase bucket documentation** — `docs/tutorials-backend.md` gains a manual setup checklist (private bucket, 50MB limit, MIME whitelist, service-role key bypasses RLS) and a video-strategy section. `.env.example` notes the bucket must be private with a matching size limit.
- **Route handler context typing** — `withAuth`'s context parameter goes from `any` to `unknown` in `src/lib/auth.ts`, narrowed at the call site in the comments DELETE route.
- **Temporary test harness** — a `/tutorialTest` route exercising the create → upload → fetch flow against real components (`FullButton`, `TextInput`), isolated on its own route. Committed separately for a clean single-commit revert.

### What's intentionally deferred

- **Test harness removal** — `src/app/tutorialTest/` is temporary; its commit should be reverted once the Supabase flow is confirmed.
- **Tutorial create UI form** — `tutorials/create/page.tsx` still has a placeholder where the editor form goes; only the copy was updated here.

### Relation to prior work

Builds on the storage abstraction (`StorageDriver`, `getStorage()`), the busboy streaming upload route, and the `AppError`/`errorToResponse` hierarchy already on the branch. No behavior changes beyond the error-code mapping and the size limit — `getStorage()` already reads `STORAGE_BACKEND` per-call, so the Supabase path needed no code change once errors were typed.
