### PR TITLE
feat: implement tooltips; enhance sidebar content i

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Inter, Sora } from "next/font/google";
 import "./globals.css";
 import { PromptProvider } from "@/contexts/PromptContext";
 import { ToastProvider } from "@/contexts/ToastContext";
+import { TooltipProvider } from "@/contexts/TooltipContext";
 
 const inter = Inter({
   variable: "--font-inter",
@@ -49,7 +50,9 @@ export default function RootLayout({
       </head>
       <body className="min-h-full flex flex-col bg-background text-text">
         <PromptProvider>
-          <ToastProvider>{children}</ToastProvider>
+          <ToastProvider>
+            <TooltipProvider>{children}</TooltipProvider>
+          </ToastProvider>
         </PromptProvider>
       </body>
     </html>

--- a/src/components/navigation/sidebar-widgets/SidebarHeatmap.tsx
+++ b/src/components/navigation/sidebar-widgets/SidebarHeatmap.tsx
@@ -2,12 +2,33 @@
 
 import React, { useEffect, useState } from "react";
 import { Activity } from "lucide-react";
+import { useTooltip } from "@/contexts/TooltipContext";
+
+const DAYS = 91; // 13 weeks × 7 days
+const COLS = 13;
+
+function formatDate(dateStr: string) {
+  return new Date(dateStr).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function getIntensityColor(count: number) {
+  if (count === 0) return "bg-gray-100 dark:bg-gray-800/50";
+  if (count === 1) return "bg-primary-200 dark:bg-primary-900/50";
+  if (count === 2) return "bg-primary-300 dark:bg-primary-700/60";
+  if (count === 3) return "bg-primary-400 dark:bg-primary-500/70";
+  return "bg-primary-500 dark:bg-primary-500";
+}
 
 export default function SidebarHeatmap() {
   const [heatmapData, setHeatmapData] = useState<
     { date: string; count: number }[]
   >([]);
   const [loading, setLoading] = useState(true);
+  const { showTooltip, hideTooltip } = useTooltip();
 
   useEffect(() => {
     const fetchHeatmap = async () => {
@@ -33,15 +54,37 @@ export default function SidebarHeatmap() {
     fetchHeatmap();
   }, []);
 
-  const getIntensityColor = (count: number) => {
-    if (count === 0) return "bg-gray-100 dark:bg-gray-800/50";
-    if (count === 1) return "bg-primary-200 dark:bg-primary-900/40";
-    if (count === 2) return "bg-primary-300 dark:bg-primary-700/60";
-    if (count === 3) return "bg-primary-500 dark:bg-primary-600/80";
-    return "bg-primary-500 dark:bg-primary-600";
-  };
-
   if (loading || heatmapData.length === 0) return null;
+  const padded: { date: string; count: number }[] = [];
+  const today = new Date();
+  for (let i = DAYS - 1; i >= 0; i--) {
+    const d = new Date(today);
+    d.setDate(today.getDate() - i);
+    const iso = d.toISOString().split("T")[0];
+    const found = heatmapData.find((h) => h.date === iso);
+    padded.push({ date: iso, count: found?.count ?? 0 });
+  }
+
+  const columns: { date: string; count: number }[][] = [];
+  for (let c = 0; c < COLS; c++) {
+    columns.push(padded.slice(c * 7, c * 7 + 7));
+  }
+
+  const monthLabels: { col: number; label: string }[] = [];
+  columns.forEach((col, ci) => {
+    const firstOfMonth = col.find((d) => new Date(d.date).getDate() <= 7);
+    if (firstOfMonth) {
+      const month = new Date(firstOfMonth.date).toLocaleString("en-US", {
+        month: "short",
+      });
+      if (
+        !monthLabels.length ||
+        monthLabels[monthLabels.length - 1].label !== month
+      ) {
+        monthLabels.push({ col: ci, label: month });
+      }
+    }
+  });
 
   return (
     <div
@@ -55,34 +98,57 @@ export default function SidebarHeatmap() {
         </h3>
       </div>
 
-      <div className="flex flex-col gap-1.5">
-        <div className="grid grid-cols-13 gap-[2px]">
-          {heatmapData.map((day, i) => (
-            <div
-              key={i}
-              className={`w-full aspect-square rounded-xs ${getIntensityColor(day.count)} transition-colors 
-              hover:ring-1 hover:ring-primary-300 cursor-help`}
-              title={`${day.date}: ${day.count} acts`}
-            />
-          ))}
+      <div className="flex flex-col gap-1">
+        <div className="flex gap-[3px]">
+          {columns.map((_, ci) => {
+            const label = monthLabels.find((m) => m.col === ci);
+            return (
+              <div
+                key={ci}
+                className="flex-1 text-[8px] text-gray-400 font-medium truncate"
+              >
+                {label?.label ?? ""}
+              </div>
+            );
+          })}
         </div>
 
-        <div className="flex items-center justify-between mt-1">
-          <span className="text-[9px] text-gray-500 font-medium">
-            Last 90 Days
-          </span>
-          <div className="flex items-center gap-1">
-            <span className="text-[9px] text-gray-500">Less</span>
-            <div className="flex gap-[2px]">
-              {[0, 1, 2, 3, 4].map((level) => (
+        <div className="flex gap-[3px]">
+          {columns.map((col, ci) => (
+            <div key={ci} className="flex flex-col gap-[3px] flex-1">
+              {col.map((day, di) => (
                 <div
-                  key={level}
-                  className={`w-1.5 h-1.5 rounded-[1px] ${getIntensityColor(level)}`}
+                  key={di}
+                  className={`w-full aspect-square rounded-[2px] ${getIntensityColor(day.count)} transition-colors hover:ring-1 hover:ring-primary-400 cursor-default`}
+                  onMouseEnter={(e) =>
+                    showTooltip(
+                      `${day.count} act${day.count !== 1 ? "s" : ""} · ${formatDate(day.date)}`,
+                      e,
+                    )
+                  }
+                  onMouseLeave={hideTooltip}
                 />
               ))}
             </div>
-            <span className="text-[9px] text-gray-500">More</span>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between mt-0.5">
+        <span className="text-[9px] text-gray-400 font-medium">
+          Last 90 days
+        </span>
+        <div className="flex items-center gap-1">
+          <span className="text-[9px] text-gray-400">Less</span>
+          <div className="flex gap-[2px]">
+            {[0, 1, 2, 3, 4].map((level) => (
+              <div
+                key={level}
+                className={`w-2 h-2 rounded-[2px] ${getIntensityColor(level)}`}
+              />
+            ))}
           </div>
+          <span className="text-[9px] text-gray-400">More</span>
         </div>
       </div>
     </div>

--- a/src/components/navigation/sidebar-widgets/SidebarLeaderboard.tsx
+++ b/src/components/navigation/sidebar-widgets/SidebarLeaderboard.tsx
@@ -2,10 +2,10 @@
 
 import React, { useEffect, useState } from "react";
 import Link from "next/link";
-import { TrendingUp, Award, User as UserIcon } from "lucide-react";
+import { Award, User as UserIcon, Zap } from "lucide-react";
 import type { User } from "@/types/database";
 
-type LeaderboardUser = User & { engagement: number };
+type LeaderboardUser = User & { weekly_acts: number };
 
 function LeaderboardRow({
   user,
@@ -14,15 +14,22 @@ function LeaderboardRow({
   user: LeaderboardUser;
   rank: number;
 }) {
+  const medalColor =
+    rank === 1
+      ? "text-yellow-500"
+      : rank === 2
+        ? "text-gray-400"
+        : rank === 3
+          ? "text-amber-600"
+          : "text-gray-400";
+
   return (
     <Link
       href={`/${user.user_name}`}
       className="flex items-center justify-between p-1.5 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors group cursor-pointer"
     >
       <div className="flex items-center gap-2">
-        <span
-          className={`text-xs font-bold w-4 text-center ${rank === 1 ? "text-yellow-500" : rank === 2 ? "text-gray-400" : rank === 3 ? "text-amber-600" : "text-gray-500"}`}
-        >
+        <span className={`text-xs font-bold w-4 text-center ${medalColor}`}>
           {rank}
         </span>
 
@@ -43,8 +50,8 @@ function LeaderboardRow({
             {user.user_name}
           </span>
           <div className="flex items-center gap-1 text-[10px] text-gray-500">
-            <TrendingUp size={10} className="text-primary-500" />
-            <span>{user.engagement} acts</span>
+            <Zap size={9} className="text-primary-500" />
+            <span>{user.weekly_acts} this week</span>
           </div>
         </div>
       </div>

--- a/src/contexts/TooltipContext.tsx
+++ b/src/contexts/TooltipContext.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useRef,
+  useEffect,
+  ReactNode,
+} from "react";
+
+interface TooltipState {
+  text: string;
+  x: number;
+  y: number;
+  visible: boolean;
+}
+
+interface TooltipContextProps {
+  showTooltip: (text: string, e: React.MouseEvent) => void;
+  hideTooltip: () => void;
+}
+
+const TooltipContext = createContext<TooltipContextProps | undefined>(
+  undefined,
+);
+
+export function TooltipProvider({ children }: { children: ReactNode }) {
+  const [tooltip, setTooltip] = useState<TooltipState>({
+    text: "",
+    x: 0,
+    y: 0,
+    visible: false,
+  });
+  const tooltipRef = useRef<HTMLDivElement>(null);
+
+  const showTooltip = useCallback((text: string, e: React.MouseEvent) => {
+    setTooltip({ text, x: e.clientX, y: e.clientY, visible: true });
+  }, []);
+
+  const hideTooltip = useCallback(() => {
+    setTooltip((prev) => ({ ...prev, visible: false }));
+  }, []);
+
+  useEffect(() => {
+    if (!tooltip.visible || !tooltipRef.current) return;
+    const el = tooltipRef.current;
+    const rect = el.getBoundingClientRect();
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+    let x = tooltip.x + 12;
+    let y = tooltip.y - 36;
+    if (x + rect.width > vw - 8) x = tooltip.x - rect.width - 12;
+    if (y < 8) y = tooltip.y + 16;
+    if (y + rect.height > vh - 8) y = vh - rect.height - 8;
+    el.style.left = `${x}px`;
+    el.style.top = `${y}px`;
+  }, [tooltip]);
+
+  return (
+    <TooltipContext.Provider value={{ showTooltip, hideTooltip }}>
+      {children}
+      {tooltip.visible && (
+        <div
+          ref={tooltipRef}
+          className="fixed z-9999 pointer-events-none px-2 py-1 rounded-md 
+          bg-gray-900 dark:bg-gray-700 text-white text-[11px] 
+          font-medium shadow-lg whitespace-nowrap animate-in fade-in duration-100"
+          style={{ left: tooltip.x + 12, top: tooltip.y - 36 }}
+        >
+          {tooltip.text}
+        </div>
+      )}
+    </TooltipContext.Provider>
+  );
+}
+
+export function useTooltip() {
+  const ctx = useContext(TooltipContext);
+  if (!ctx) throw new Error("useTooltip must be used within a TooltipProvider");
+  return ctx;
+}

--- a/src/lib/queries/users.ts
+++ b/src/lib/queries/users.ts
@@ -127,21 +127,27 @@ export async function getUserMetrics(user_id: UserID): Promise<Metrics> {
 }
 
 export async function getTopContributorsThisWeek(limit: number = 5) {
-  const rows = await q<UserRow & { engagement: string }>(
+  const rows = await q<UserRow & { engagement: string; weekly_acts: string }>(
     `SELECT u.*,
+      u.credibility_score as engagement,
       (
-        (SELECT COUNT(*) FROM questions q WHERE q.user_id = u.user_id AND q.created_at >= NOW() - INTERVAL '7 days') * 3 +
-        (SELECT COUNT(*) FROM answers a WHERE a.user_id = u.user_id AND a.created_at >= NOW() - INTERVAL '7 days') * 5
-      ) as engagement
+        (SELECT COUNT(*) FROM questions q WHERE q.user_id = u.user_id AND q.created_at >= NOW() - INTERVAL '7 days') +
+        (SELECT COUNT(*) FROM answers  a WHERE a.user_id = u.user_id AND a.created_at >= NOW() - INTERVAL '7 days') +
+        (SELECT COUNT(*) FROM comments c WHERE c.user_id = u.user_id AND c.created_at >= NOW() - INTERVAL '7 days')
+      ) as weekly_acts
      FROM users u
-     ORDER BY engagement DESC
+     ORDER BY weekly_acts DESC, engagement DESC
      LIMIT $1`,
     [limit],
   );
 
   return rows.map((r) => {
     const user = mapUser(r);
-    return { ...user, engagement: Number(r.engagement) };
+    return {
+      ...user,
+      engagement: Number(r.engagement),
+      weekly_acts: Number(r.weekly_acts),
+    };
   });
 }
 


### PR DESCRIPTION
- created TooltipContext and ToolTipProvider for handling hover tootltips with automatic clamping
- refactored SidebarHeatmap to follow the style of Github's column-based layout for the last 91 days, includes month labels and uses activity tooltips now
- refactored SidebarLeaderboard to use weekly activity (questions, answers, comments)
- updated backend query 'getTopContributorsThisWeek' to fetch and return raw weekly activity counts alongside engagement scores.